### PR TITLE
libavformat/mxfdec - (SSIMWAVE) Skip parsing timestamps of JPEG2000 c…

### DIFF
--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -2547,7 +2547,9 @@ static int mxf_parse_structural_metadata(MXFContext *mxf)
             if (ret < 0)
                 return ret;
         }
-        if (st->codecpar->codec_type != AVMEDIA_TYPE_DATA && source_track->wrapping != FrameWrapped) {
+        if (st->codecpar->codec_type != AVMEDIA_TYPE_DATA
+            && source_track->wrapping != FrameWrapped
+            && st->codecpar->codec_id != AV_CODEC_ID_JPEG2000) {
             /* TODO: decode timestamps */
             st->need_parsing = AVSTREAM_PARSE_TIMESTAMPS;
         }


### PR DESCRIPTION
…ontent in MXF containers