### PR TITLE
dashdec: restrict refresh_manifest error return

### DIFF
--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -1692,7 +1692,7 @@ static int get_current_fragment(struct representation *pls, struct fragment** ne
             return 0;
         } else if (c->is_live) {
             err = refresh_manifest(pls->parent);
-            if (0 != err) {
+            if (AVERROR_INPUT_CHANGED == err) {
                 return err;
             }
         } else {
@@ -1705,7 +1705,7 @@ static int get_current_fragment(struct representation *pls, struct fragment** ne
 
         if (pls->timelines || pls->fragments) {
             err = refresh_manifest(pls->parent);
-            if (0 != err) {
+            if (AVERROR_INPUT_CHANGED == err) {
                 return err;
             }
         }


### PR DESCRIPTION
Only return an error when the input changes.  Otherwise, this causes
issues with av_read_frame() returning AVERROR_INVALIDDATA when the
server stops responding to manifest requests.