### PR TITLE
http: add notifications for http response codes

### DIFF
--- a/libavformat/avformat.h
+++ b/libavformat/avformat.h
@@ -1951,6 +1951,14 @@ typedef struct AVFormatContext {
      * - decoding: set by user
      */
     int max_probe_packets;
+
+    /**
+     * SSIMWAVE
+     * Callback to notify clients for ABR formats when an HTTP response has been received
+     */
+    void (*http_response_code_callback)(void* opaque, const char* url, const char* method, int response_code);
+    void* http_response_code_callback_context;
+
 } AVFormatContext;
 
 #if FF_API_FORMAT_GET_SET


### PR DESCRIPTION
Cache http response codes in the client's dictionary to report them back
to the application layer through a callback.

This approach was taken to avoid extensive changes to the internal API.

Invoke http callbacks in both the hls and http demuxers where they can
be populated through the AVFormatContext.