### PR TITLE
dashdec/hls: Supply AVStream IDs in HTTP callbacks

### DIFF
--- a/libavformat/avformat.h
+++ b/libavformat/avformat.h
@@ -1956,7 +1956,8 @@ typedef struct AVFormatContext {
      * SSIMWAVE
      * Callback to notify clients for ABR formats when an HTTP response has been received
      */
-    void (*http_response_code_callback)(void* opaque, const char* url, const char* method, int response_code);
+    void (*http_response_code_callback)(void* opaque, const int* av_stream_ids, size_t num_av_stream_ids,
+                                        const char* url, const char* method, int response_code);
     void* http_response_code_callback_context;
 
 } AVFormatContext;


### PR DESCRIPTION
Due to the nature of dynamic UUIDs in, supplying the URL is not good enough to map a response to an ABR stream.
Add the AVStream ID values in a list for the consumer to use for mapping purposes.