### PR TITLE
dashdec/hls: Use stream index in http callbacks

### DIFF
--- a/libavformat/avformat.h
+++ b/libavformat/avformat.h
@@ -1956,7 +1956,7 @@ typedef struct AVFormatContext {
      * SSIMWAVE
      * Callback to notify clients for ABR formats when an HTTP response has been received
      */
-    void (*http_response_code_callback)(void* opaque, const int* av_stream_ids, size_t num_av_stream_ids,
+    void (*http_response_code_callback)(void* opaque, const int* av_stream_indices, size_t num_av_stream_indices,
                                         const char* url, const char* method, int response_code);
     void* http_response_code_callback_context;
 

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -491,7 +491,7 @@ static int open_url(AVFormatContext *s, AVIOContext **pb, const char *url,
             if (method_entry && status_code_entry) {
                 int status_code_int = strtoul(status_code_entry->value, NULL, 10);
                 s->http_response_code_callback(s->http_response_code_callback_context,
-                                               &stream->id, 1,
+                                               &stream->index, 1,
                                                url, method_entry->value, status_code_int);
             }
         }

--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -43,7 +43,7 @@
 
 #define MAX_FIELD_LEN 64
 #define MAX_CHARACTERISTICS_LEN 512
-#define MAX_AV_STREAM_IDS 64
+#define MAX_AV_STREAM_INDEX 64
 
 #define MPEG_TIME_BASE 90000
 #define MPEG_TIME_BASE_Q (AVRational){1, MPEG_TIME_BASE}
@@ -785,13 +785,13 @@ static int open_url(AVFormatContext *s, AVIOContext **pb, const char *url,
             AVDictionaryEntry* status_code_entry = av_dict_get(tmp, "http_cache_status_code", NULL, 0);
             if (method_entry && status_code_entry) {
                 int status_code_int = strtoul(status_code_entry->value, NULL, 10);
-                int av_stream_ids[MAX_AV_STREAM_IDS];
+                int av_stream_indices[MAX_AV_STREAM_INDEX];
                 size_t index = 0;
-                for (index = 0; index < num_streams && index < MAX_AV_STREAM_IDS; ++index) {
-                    av_stream_ids[index] = streams[index]->id;
+                for (index = 0; index < num_streams && index < MAX_AV_STREAM_INDEX; ++index) {
+                    av_stream_indices[index] = streams[index]->index;
                 }
                 s->http_response_code_callback(s->http_response_code_callback_context,
-                                               av_stream_ids, FFMIN(num_streams, MAX_AV_STREAM_IDS),
+                                               av_stream_indices, FFMIN(num_streams, MAX_AV_STREAM_INDEX),
                                                url, method_entry->value, status_code_int);
             }
         }


### PR DESCRIPTION
Our external product code keeps track of FFmpeg streams based on index, so provide that information in the callback.