### PR TITLE
mxfdec: PHDR metadata track extraction

### DIFF
--- a/libavformat/mxf.h
+++ b/libavformat/mxf.h
@@ -53,6 +53,8 @@ enum MXFMetadataSetType {
     AudioChannelLabelSubDescriptor,
     SoundfieldGroupLabelSubDescriptor,
     GroupOfSoundfieldGroupsLabelSubDescriptor,
+    PHDRMetadataTrackSubDescriptor,
+    PHDRDoViGlobalData,
 };
 
 enum MXFFrameLayout {

--- a/libavformat/mxf.h
+++ b/libavformat/mxf.h
@@ -134,6 +134,7 @@ int ff_mxf_get_content_package_rate(AVRational time_base);
     (x)[8],  (x)[9],  (x)[10], (x)[11],     \
     (x)[12], (x)[13], (x)[14], (x)[15]      \
 
+#define DEBUG 1
 #ifdef DEBUG
 #define PRINT_KEY(pc, s, x)                         \
     av_log(pc, AV_LOG_VERBOSE,                      \
@@ -161,5 +162,7 @@ int ff_mxf_get_content_package_rate(AVRational time_base);
             s, UID_ARG(x));                         \
     }while(0)
 #endif
+
+#undef DEBUG
 
 #endif /* AVFORMAT_MXF_H */

--- a/libavformat/mxf.h
+++ b/libavformat/mxf.h
@@ -134,7 +134,6 @@ int ff_mxf_get_content_package_rate(AVRational time_base);
     (x)[8],  (x)[9],  (x)[10], (x)[11],     \
     (x)[12], (x)[13], (x)[14], (x)[15]      \
 
-#define DEBUG 1
 #ifdef DEBUG
 #define PRINT_KEY(pc, s, x)                         \
     av_log(pc, AV_LOG_VERBOSE,                      \
@@ -162,7 +161,5 @@ int ff_mxf_get_content_package_rate(AVRational time_base);
             s, UID_ARG(x));                         \
     }while(0)
 #endif
-
-#undef DEBUG
 
 #endif /* AVFORMAT_MXF_H */

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -3321,7 +3321,8 @@ static int mxf_read_phdr_dovi_global_metadata(void *arg, AVIOContext *pb, int ta
         return AVERROR(ENOMEM);
     }
 
-    mxf->dovi_global_metadata->data = av_mallocz(size);
+    // Global metadata is not null terminated, we must do it ourselves to treat as a string when stored in a dictionary
+    mxf->dovi_global_metadata->data = av_mallocz(size + 1);
     if (!mxf->dovi_global_metadata->data) {
         return AVERROR(ENOMEM);
     }
@@ -3329,6 +3330,7 @@ static int mxf_read_phdr_dovi_global_metadata(void *arg, AVIOContext *pb, int ta
     mxf->dovi_global_metadata->length = size;
 
     read_res = avio_read(pb, mxf->dovi_global_metadata->data, size);
+    mxf->dovi_global_metadata->data[size] = '\0';
 
     if (read_res >= 0) {
         av_log(NULL, AV_LOG_TRACE, "PHDR global data: read %d bytes\n", read_res);

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -324,6 +324,7 @@ typedef struct MXFContext {
     int eia608_extract;
     int dovi_metadata_extract;
     int dovi_metadata_stream_index;
+    MXFPHDRDoViGlobalMetadata *dovi_global_metadata;
 } MXFContext;
 
 /* NOTE: klv_offset is not set (-1) for local keys */
@@ -429,9 +430,6 @@ static void mxf_free_metadataset(MXFMetadataSet **ctx, int freectx)
         av_freep(&seg->temporal_offset_entries);
         av_freep(&seg->flag_entries);
         av_freep(&seg->stream_offset_entries);
-        break;
-    case PHDRDoViGlobalData:
-        av_freep(&((MXFPHDRDoViGlobalMetadata*)*ctx)->data);
         break;
     default:
         break;
@@ -2482,35 +2480,15 @@ static MXFTrack* mxf_get_dovi_metadata_track(MXFContext* mxf)
 
 static int mxf_init_dovi_metadata_stream(MXFContext* mxf, AVStream* st)
 {
-    MXFPHDRDoViGlobalMetadata* global_metadata = NULL;
-    AVDictionary* metadata_dict = NULL;
-    char* packed_metadata = NULL;
-    size_t metadata_len = 0;
     int ret = 0;
 
-    for (size_t k = 0; k < mxf->metadata_sets_count; k++) {
-        MXFMetadataSet *metadata = mxf->metadata_sets[k];
-        if (metadata->type == PHDRDoViGlobalData) {
-            global_metadata = (MXFPHDRDoViGlobalMetadata*)metadata;
-            break;
-        }
-    }
-
-    if (!global_metadata) {
+    if (!mxf->dovi_global_metadata) {
+        av_log(NULL, AV_LOG_TRACE, "no Dolby Vision global metadata found in metadata sets\n");
         return AVERROR_INVALIDDATA;
     }
 
-    if ((ret = av_dict_set(&metadata_dict, "doViGlobalMetadata", global_metadata->data, 0 /* flags */))) {
-        return ret;
-    }
-
-    packed_metadata = av_packet_pack_dictionary(metadata_dict, &metadata_len);
-    av_dict_free(&metadata_dict);
-    if (!packed_metadata) {
-        return AVERROR(ENOMEM);
-    }
-
-    return av_stream_add_side_data(st, AV_PKT_DATA_STRINGS_METADATA, packed_metadata, metadata_len);
+    ret = av_dict_set(&st->metadata, "dovi_global_metadata", mxf->dovi_global_metadata->data, 0 /* flags */);
+    return ret;
 }
 
 static int mxf_add_dovi_metadata_stream(MXFContext* mxf)
@@ -3335,17 +3313,22 @@ static int mxf_read_phdr_metadata_track_sub_descriptor(void *arg, AVIOContext *p
 
 static int mxf_read_phdr_dovi_global_metadata(void *arg, AVIOContext *pb, int tag, int size, UID uid, int64_t klv_offset)
 {
-    MXFPHDRDoViGlobalMetadata *phdr_dovi_global_metadata = arg;
+    MXFContext *mxf = arg;
     int read_res = 0;
 
-    phdr_dovi_global_metadata->data = av_mallocz(size);
-    phdr_dovi_global_metadata->length = size;
+    mxf->dovi_global_metadata = av_mallocz(sizeof(mxf->dovi_global_metadata));
+    if (!mxf->dovi_global_metadata) {
+        return AVERROR(ENOMEM);
+    }
 
-    read_res = avio_read(pb, phdr_dovi_global_metadata->data, size);
+    mxf->dovi_global_metadata->data = av_mallocz(size);
+    mxf->dovi_global_metadata->length = size;
+
+    read_res = avio_read(pb, mxf->dovi_global_metadata->data, size);
 
     if (read_res >= 0) {
         av_log(NULL, AV_LOG_TRACE, "PHDR global data: read %d bytes\n", read_res);
-        av_log(NULL, AV_LOG_TRACE, "PHDR global data body: %s", phdr_dovi_global_metadata->data);
+        av_log(NULL, AV_LOG_TRACE, "PHDR global data body: %s", mxf->dovi_global_metadata->data);
     }
     else {
         av_log(NULL, AV_LOG_TRACE, "Failed to read PHDR global data: result %d\n", read_res);
@@ -3424,10 +3407,6 @@ static int mxf_read_local_tags(MXFContext *mxf, KLVPacket *klv, MXFMetadataReadF
     uint64_t klv_end = avio_tell(pb) + klv->length;
     MXFMetadataSet *meta;
     void *ctx;
-
-    if (type == PHDRMetadataTrackSubDescriptor) {
-        av_log(mxf->fc, AV_LOG_TRACE, "attempt to read phdr\n");
-    }
 
     if (ctx_size) {
         meta = av_mallocz(ctx_size);
@@ -4275,6 +4254,11 @@ static int mxf_read_close(AVFormatContext *s)
     av_freep(&mxf->metadata_sets);
     av_freep(&mxf->aesc);
     av_freep(&mxf->local_tags);
+
+    if (mxf->dovi_global_metadata) {
+        av_freep(&mxf->dovi_global_metadata->data);
+        av_freep(&mxf->dovi_global_metadata);
+    }
 
     if (mxf->index_tables) {
         for (i = 0; i < mxf->nb_index_tables; i++) {

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -4154,12 +4154,14 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
             IS_KLV_KEY(klv.key, mxf_avid_essence_element_key) ||
             (is_phdr = IS_KLV_KEY(klv.key, mxf_phdr_image_metadata_item))) {
             int body_sid = find_body_sid_by_absolute_offset(mxf, klv.offset);
-            int index = (mxf->dovi_metadata_extract && is_phdr) ?
-                mxf->dovi_metadata_stream_index : mxf_get_stream_index(s, &klv, body_sid);
+            int index = is_phdr ? mxf->dovi_metadata_stream_index : mxf_get_stream_index(s, &klv, body_sid);
             int64_t next_ofs;
             AVStream *st;
             MXFTrack *track;
 
+            if (is_phdr && !mxf->dovi_metadata_extract) {
+                goto skip;
+            }
             if (index < 0) {
                 av_log(s, AV_LOG_ERROR,
                        "error getting stream index %"PRIu32"\n",

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -2475,7 +2475,7 @@ static MXFTrack* mxf_get_dovi_metadata_track(MXFContext* mxf)
         }
     }
 
-    av_log(NULL, AV_LOG_TRACE, "found in use Dolby Vision metadata track id %" PRIu64 "\n", track_id);
+    av_log(mxf->fc, AV_LOG_TRACE, "found in use Dolby Vision metadata track id %" PRIu64 "\n", track_id);
     return dovi_metadata_track;
 }
 
@@ -2484,7 +2484,7 @@ static int mxf_init_dovi_metadata_stream(MXFContext* mxf, AVStream* st)
     int ret = 0;
 
     if (!mxf->dovi_global_metadata) {
-        av_log(NULL, AV_LOG_TRACE, "no Dolby Vision global metadata found in metadata sets\n");
+        av_log(mxf->fc, AV_LOG_TRACE, "no Dolby Vision global metadata found in metadata sets\n");
         return AVERROR_INVALIDDATA;
     }
 
@@ -2527,7 +2527,7 @@ static int mxf_add_dovi_metadata_stream(MXFContext* mxf)
     }
 
     st->codecpar->codec_type = AVMEDIA_TYPE_DATA;
-    st->codecpar->codec_id = AV_CODEC_ID_NONE;
+    st->codecpar->codec_id = AV_CODEC_ID_BIN_DATA;
     st->id = track->track_id;
 
     if (track->name && track->name[0]) {
@@ -2538,7 +2538,7 @@ static int mxf_add_dovi_metadata_stream(MXFContext* mxf)
         av_dict_set(&st->metadata, "data_type", container_ul->desc, 0);
     }
 
-    av_log(NULL, AV_LOG_TRACE, "added in use Dolby Vision metadata track id %u\n", track->track_id);
+    av_log(mxf->fc, AV_LOG_TRACE, "added in use Dolby Vision metadata track id %u\n", track->track_id);
     if (track->edit_rate.num <= 0 ||
         track->edit_rate.den <= 0) {
         av_log(mxf->fc, AV_LOG_WARNING,
@@ -3327,6 +3327,7 @@ static int mxf_read_phdr_dovi_global_metadata(void *arg, AVIOContext *pb, int ta
     // Global metadata is not null terminated, we must do it ourselves to treat as a string when stored in a dictionary
     mxf->dovi_global_metadata->data = av_mallocz(size + 1);
     if (!mxf->dovi_global_metadata->data) {
+        av_freep(&mxf->dovi_global_metadata);
         return AVERROR(ENOMEM);
     }
 
@@ -3336,11 +3337,13 @@ static int mxf_read_phdr_dovi_global_metadata(void *arg, AVIOContext *pb, int ta
     mxf->dovi_global_metadata->data[size] = '\0';
 
     if (read_res >= 0) {
-        av_log(NULL, AV_LOG_TRACE, "PHDR global data: read %d bytes\n", read_res);
-        av_log(NULL, AV_LOG_TRACE, "PHDR global data body: %s", mxf->dovi_global_metadata->data);
+        av_log(mxf->fc, AV_LOG_TRACE, "PHDR global data: read %d bytes\n", read_res);
+        av_log(mxf->fc, AV_LOG_TRACE, "PHDR global data body: %s", mxf->dovi_global_metadata->data);
     }
     else {
-        av_log(NULL, AV_LOG_TRACE, "Failed to read PHDR global data: result %d\n", read_res);
+        av_log(mxf->fc, AV_LOG_TRACE, "Failed to read PHDR global data: result %d\n", read_res);
+        av_freep(&mxf->dovi_global_metadata->data)
+        av_freep(&mxf->dovi_global_metadata);
     }
     return read_res;
 }

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -3342,7 +3342,7 @@ static int mxf_read_phdr_dovi_global_metadata(void *arg, AVIOContext *pb, int ta
     }
     else {
         av_log(mxf->fc, AV_LOG_TRACE, "Failed to read PHDR global data: result %d\n", read_res);
-        av_freep(&mxf->dovi_global_metadata->data)
+        av_freep(&mxf->dovi_global_metadata->data);
         av_freep(&mxf->dovi_global_metadata);
     }
     return read_res;

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -283,7 +283,6 @@ typedef struct MXFPHDRDoViGlobalMetadata {
     size_t length;
     char* data;
 } MXFPHDRDoViGlobalMetadata;
-// TODO need to free "data" when the context is destroyed
 
 /* decoded index table */
 typedef struct MXFIndexTable {
@@ -2481,7 +2480,40 @@ static MXFTrack* mxf_get_dovi_metadata_track(MXFContext* mxf)
     return dovi_metadata_track;
 }
 
-static void mxf_add_dovi_metadata_track(MXFContext* mxf)
+static int mxf_init_dovi_metadata_stream(MXFContext* mxf, AVStream* st)
+{
+    MXFPHDRDoViGlobalMetadata* global_metadata = NULL;
+    AVDictionary* metadata_dict = NULL;
+    char* packed_metadata = NULL;
+    size_t metadata_len = 0;
+    int ret = 0;
+
+    for (size_t k = 0; k < mxf->metadata_sets_count; k++) {
+        MXFMetadataSet *metadata = mxf->metadata_sets[k];
+        if (metadata->type == PHDRDoViGlobalData) {
+            global_metadata = (MXFPHDRDoViGlobalMetadata*)metadata;
+            break;
+        }
+    }
+
+    if (!global_metadata) {
+        return AVERROR_INVALIDDATA;
+    }
+
+    if ((ret = av_dict_set(&metadata_dict, "doViGlobalMetadata", global_metadata->data, 0 /* flags */))) {
+        return ret;
+    }
+
+    packed_metadata = av_packet_pack_dictionary(metadata_dict, &metadata_len);
+    av_dict_free(&metadata_dict);
+    if (!packed_metadata) {
+        return AVERROR(ENOMEM);
+    }
+
+    return av_stream_add_side_data(st, AV_PKT_DATA_STRINGS_METADATA, packed_metadata, metadata_len);
+}
+
+static int mxf_add_dovi_metadata_stream(MXFContext* mxf)
 {
     MXFTrack* track = NULL;
     MXFStructuralComponent *component = NULL;
@@ -2489,12 +2521,12 @@ static void mxf_add_dovi_metadata_track(MXFContext* mxf)
     AVStream *st = NULL;
 
     if (!(track = mxf_get_dovi_metadata_track(mxf))) {
-        return;
+        return 0;
     }
 
     if (!(track->sequence = mxf_resolve_strong_ref(mxf, &track->sequence_ref, Sequence))) {
-        av_log(mxf->fc, AV_LOG_ERROR, "could not resolve material track sequence strong ref\n");
-        return;
+        av_log(mxf->fc, AV_LOG_ERROR, "could not resolve track sequence strong ref\n");
+        return AVERROR_INVALIDDATA;
     }
 
     for (size_t j = 0; j < track->sequence->structural_components_count; j++) {
@@ -2503,13 +2535,15 @@ static void mxf_add_dovi_metadata_track(MXFContext* mxf)
             break;
         }
     }
-    if (!component)
-        return;
+    if (!component) {
+        av_log(mxf->fc, AV_LOG_ERROR, "could not resolve source clip\n");
+        return AVERROR_INVALIDDATA;
+    }
 
     st = avformat_new_stream(mxf->fc, NULL);
     if (!st) {
         av_log(mxf->fc, AV_LOG_ERROR, "could not allocate DoVi metadata stream\n");
-        return;
+        return AVERROR(ENOMEM);
     }
 
     st->codecpar->codec_type = AVMEDIA_TYPE_DATA;
@@ -2519,15 +2553,12 @@ static void mxf_add_dovi_metadata_track(MXFContext* mxf)
     if (track->name && track->name[0]) {
         av_dict_set(&st->metadata, "track_name", track->name, 0);
     }
-
-    PRINT_KEY(mxf->fc, "essence container ul", track->sequence->data_definition_ul);
     container_ul = mxf_get_codec_ul(mxf_data_essence_container_uls, &track->sequence->data_definition_ul);
     if (container_ul->desc) {
         av_dict_set(&st->metadata, "data_type", container_ul->desc, 0);
     }
 
     av_log(NULL, AV_LOG_TRACE, "added in use Dolby Vision metadata track id %u\n", track->track_id);
-
     if (track->edit_rate.num <= 0 ||
         track->edit_rate.den <= 0) {
         av_log(mxf->fc, AV_LOG_WARNING,
@@ -2540,7 +2571,13 @@ static void mxf_add_dovi_metadata_track(MXFContext* mxf)
     avpriv_set_pts_info(st, 64, track->edit_rate.den, track->edit_rate.num);
 
     st->priv_data = track;
+
+    if (mxf_init_dovi_metadata_stream(mxf, st)) {
+        av_log(mxf->fc, AV_LOG_ERROR, "failed to fully initialize DoVi metadata stream\n");
+    }
+
     mxf->dovi_metadata_stream_index = st->index;
+    return 0;
 }
 
 static enum AVColorRange mxf_get_color_range(MXFContext *mxf, MXFDescriptor *descriptor)
@@ -3298,8 +3335,6 @@ static int mxf_read_phdr_metadata_track_sub_descriptor(void *arg, AVIOContext *p
 
 static int mxf_read_phdr_dovi_global_metadata(void *arg, AVIOContext *pb, int tag, int size, UID uid, int64_t klv_offset)
 {
-    // TODO verify the body SID?
-    // TODO only extract when asked to
     MXFPHDRDoViGlobalMetadata *phdr_dovi_global_metadata = arg;
     int read_res = 0;
 
@@ -3916,7 +3951,9 @@ static int mxf_read_header(AVFormatContext *s)
     if ((ret = mxf_parse_structural_metadata(mxf)) < 0)
         return ret;
 
-    mxf_add_dovi_metadata_track(mxf);
+    if (mxf->dovi_metadata_extract) {
+        mxf_add_dovi_metadata_stream(mxf);
+    }
 
     for (int i = 0; i < s->nb_streams; i++)
         mxf_handle_missing_index_segment(mxf, s->streams[i]);
@@ -4126,7 +4163,8 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
             IS_KLV_KEY(klv.key, mxf_avid_essence_element_key) ||
             (is_phdr = IS_KLV_KEY(klv.key, mxf_phdr_image_metadata_item))) {
             int body_sid = find_body_sid_by_absolute_offset(mxf, klv.offset);
-            int index = is_phdr ? mxf->dovi_metadata_stream_index : mxf_get_stream_index(s, &klv, body_sid);
+            int index = (mxf->dovi_metadata_extract && is_phdr) ?
+                mxf->dovi_metadata_stream_index : mxf_get_stream_index(s, &klv, body_sid);
             int64_t next_ofs;
             AVStream *st;
             MXFTrack *track;
@@ -4393,7 +4431,7 @@ static const AVOption options[] = {
       offsetof(MXFContext, eia608_extract), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1,
       AV_OPT_FLAG_DECODING_PARAM },
     { "dovi_metadata_extract", "extract Dolby Vision metadata",
-      offsetof(MXFContext, dovi_metadata_extract), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1,
+      offsetof(MXFContext, dovi_metadata_extract), AV_OPT_TYPE_BOOL, {.i64 = 1}, 0, 1,
       AV_OPT_FLAG_DECODING_PARAM },
     { NULL },
 };

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -3316,12 +3316,16 @@ static int mxf_read_phdr_dovi_global_metadata(void *arg, AVIOContext *pb, int ta
     MXFContext *mxf = arg;
     int read_res = 0;
 
-    mxf->dovi_global_metadata = av_mallocz(sizeof(mxf->dovi_global_metadata));
+    mxf->dovi_global_metadata = av_mallocz(sizeof(*mxf->dovi_global_metadata));
     if (!mxf->dovi_global_metadata) {
         return AVERROR(ENOMEM);
     }
 
     mxf->dovi_global_metadata->data = av_mallocz(size);
+    if (!mxf->dovi_global_metadata->data) {
+        return AVERROR(ENOMEM);
+    }
+
     mxf->dovi_global_metadata->length = size;
 
     read_res = avio_read(pb, mxf->dovi_global_metadata->data, size);
@@ -3913,7 +3917,7 @@ static int mxf_read_header(AVFormatContext *s)
             }
         }
         if (!metadata->read) {
-            av_log(s, AV_LOG_VERBOSE, "testing Dark key " PRIxUID "\n",
+            av_log(s, AV_LOG_VERBOSE, "Dark key " PRIxUID "\n",
                             UID_ARG(klv.key));
             avio_skip(s->pb, klv.length);
         }

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -4427,7 +4427,7 @@ static const AVOption options[] = {
       offsetof(MXFContext, eia608_extract), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1,
       AV_OPT_FLAG_DECODING_PARAM },
     { "dovi_metadata_extract", "extract Dolby Vision metadata",
-      offsetof(MXFContext, dovi_metadata_extract), AV_OPT_TYPE_BOOL, {.i64 = 1}, 0, 1,
+      offsetof(MXFContext, dovi_metadata_extract), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1,
       AV_OPT_FLAG_DECODING_PARAM },
     { NULL },
 };

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -2480,16 +2480,15 @@ static MXFTrack* mxf_get_dovi_metadata_track(MXFContext* mxf)
 
 static int mxf_init_dovi_metadata_stream(MXFContext* mxf, AVStream* st)
 {
-    //int ret = 0;
+    int ret = 0;
 
     if (!mxf->dovi_global_metadata) {
         av_log(NULL, AV_LOG_TRACE, "no Dolby Vision global metadata found in metadata sets\n");
         return AVERROR_INVALIDDATA;
     }
 
-    //ret = av_dict_set(&st->metadata, "dovi_global_metadata", mxf->dovi_global_metadata->data, 0 /* flags */);
-    //return ret;
-    return 0;
+    ret = av_dict_set(&st->metadata, "dovi_global_metadata", mxf->dovi_global_metadata->data, 0 /* flags */);
+    return ret;
 }
 
 static int mxf_add_dovi_metadata_stream(MXFContext* mxf)

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -2489,7 +2489,7 @@ static int mxf_init_dovi_metadata_stream(MXFContext* mxf, AVStream* st)
 
     //ret = av_dict_set(&st->metadata, "dovi_global_metadata", mxf->dovi_global_metadata->data, 0 /* flags */);
     //return ret;
-    return 0
+    return 0;
 }
 
 static int mxf_add_dovi_metadata_stream(MXFContext* mxf)

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -2480,7 +2480,7 @@ static MXFTrack* mxf_get_dovi_metadata_track(MXFContext* mxf)
 
 static int mxf_init_dovi_metadata_stream(MXFContext* mxf, AVStream* st)
 {
-    int ret = 0;
+    //int ret = 0;
 
     if (!mxf->dovi_global_metadata) {
         av_log(NULL, AV_LOG_TRACE, "no Dolby Vision global metadata found in metadata sets\n");

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -271,6 +271,19 @@ typedef struct MXFEssenceContainerData {
     int body_sid;
 } MXFEssenceContainerData;
 
+typedef struct MXFPHDRMetadataTrackSubDescriptor {
+    MXFMetadataSet meta;
+    UID package_uid;
+    uint32_t source_track_id;
+    uint32_t simple_payload_id;
+} MXFPHDRMetadataTrackSubDescriptor;
+
+typedef struct MXFPHDRDoViGlobalMetadata {
+    MXFMetadataSet meta;
+    size_t length;
+    char* data;
+} MXFPHDRDoViGlobalMetadata;
+
 /* decoded index table */
 typedef struct MXFIndexTable {
     int index_sid;
@@ -309,6 +322,7 @@ typedef struct MXFContext {
     int nb_index_tables;
     MXFIndexTable *index_tables;
     int eia608_extract;
+    int dovi_metadata_extract;
 } MXFContext;
 
 /* NOTE: klv_offset is not set (-1) for local keys */
@@ -361,6 +375,13 @@ static const uint8_t mxf_mastering_display_uls[4][16] = {
     FF_MXF_MasteringDisplayMaximumLuminance,
     FF_MXF_MasteringDisplayMinimumLuminance,
 };
+
+static const uint8_t mxf_phdr_image_metadata_wrapping_frame[]   = { 0x06,0x0e,0x2b,0x34,0x04,0x01,0x01,0x05,0x0e,0x09,0x06,0x07,0x01,0x01,0x01,0x01 };
+static const uint8_t mxf_phdr_image_metadata_item[]             = { 0x06,0x0e,0x2b,0x34,0x01,0x02,0x01,0x05,0x0e,0x09,0x06,0x07,0x01,0x01,0x01,0x00 };
+static const uint8_t mxf_phdr_data_definition[]                 = { 0x06,0x0e,0x2b,0x34,0x01,0x01,0x01,0x05,0x0e,0x09,0x06,0x07,0x01,0x01,0x01,0x04 };
+static const uint8_t mxf_phdr_source_track_id[]                 = { 0x06,0x0e,0x2b,0x34,0x01,0x01,0x01,0x05,0x0e,0x09,0x06,0x07,0x01,0x01,0x01,0x05 };
+static const uint8_t mxf_phdr_simple_payload_sid[]              = { 0x06,0x0e,0x2b,0x34,0x01,0x01,0x01,0x05,0x0e,0x09,0x06,0x07,0x01,0x01,0x01,0x06 };
+static const uint8_t mxf_phdr_dovi_global_metadata[]            = { 0x06,0x0e,0x2b,0x34,0x01,0x01,0x01,0x0c,0x0d,0x01,0x05,0x09,0x01,0x00,0x00,0x00 };
 
 #define IS_KLV_KEY(x, y) (!memcmp(x, y, sizeof(y)))
 
@@ -771,6 +792,7 @@ static int mxf_read_partition_pack(void *arg, AVIOContext *pb, int tag, int size
         return AVERROR_INVALIDDATA;
     }
     nb_essence_containers = avio_rb32(pb);
+
 
     if (partition->type == Header) {
         char str[36];
@@ -3158,6 +3180,39 @@ static int mxf_read_preface_metadata(void *arg, AVIOContext *pb, int tag, int si
     return 0;
 }
 
+static int mxf_read_phdr_metadata_track_sub_descriptor(void *arg, AVIOContext *pb, int tag, int size, UID uid, int64_t klv_offset)
+{
+    MXFPHDRMetadataTrackSubDescriptor *phdr_metadata_track_sub_descriptor = arg;
+
+    if (IS_KLV_KEY(uid, mxf_phdr_source_track_id)) {
+        phdr_metadata_track_sub_descriptor->source_track_id = avio_rb32(pb);
+        av_log(NULL, AV_LOG_TRACE, "PHDR source track id %u\n", phdr_metadata_track_sub_descriptor->source_track_id);
+    }
+    else if (IS_KLV_KEY(uid, mxf_phdr_simple_payload_sid)) {
+        phdr_metadata_track_sub_descriptor->simple_payload_id = avio_rb32(pb);
+        av_log(NULL, AV_LOG_TRACE, "PHDR payload id %u\n", phdr_metadata_track_sub_descriptor->simple_payload_id);
+    }
+
+    return 0;
+}
+
+static int mxf_read_phdr_dovi_global_metadata(void *arg, AVIOContext *pb, int tag, int size, UID uid, int64_t klv_offset)
+{
+    // TODO verify the body SID?
+    // TODO only extract when asked to
+    MXFPHDRDoViGlobalMetadata *phdr_dovi_global_metadata = arg;
+    int read_res = 0;
+
+    phdr_dovi_global_metadata->data = av_mallocz(size);
+    phdr_dovi_global_metadata->length = size;
+
+    read_res = avio_read(pb, phdr_dovi_global_metadata->data, size);
+
+    av_log(NULL, AV_LOG_TRACE, "PHDR global data: read result %d, read %zu bytes\n", read_res, phdr_dovi_global_metadata->length);
+    av_log(NULL, AV_LOG_TRACE, "PHDR global data body: %s", phdr_dovi_global_metadata->data);
+    return read_res;
+}
+
 static const MXFMetadataReadTableEntry mxf_metadata_read_table[] = {
     { { 0x06,0x0e,0x2b,0x34,0x02,0x05,0x01,0x01,0x0d,0x01,0x02,0x01,0x01,0x05,0x01,0x00 }, mxf_read_primer_pack },
     { { 0x06,0x0e,0x2b,0x34,0x02,0x05,0x01,0x01,0x0d,0x01,0x02,0x01,0x01,0x02,0x01,0x00 }, mxf_read_partition_pack },
@@ -3168,6 +3223,7 @@ static const MXFMetadataReadTableEntry mxf_metadata_read_table[] = {
     { { 0x06,0x0e,0x2b,0x34,0x02,0x05,0x01,0x01,0x0d,0x01,0x02,0x01,0x01,0x03,0x02,0x00 }, mxf_read_partition_pack },
     { { 0x06,0x0e,0x2b,0x34,0x02,0x05,0x01,0x01,0x0d,0x01,0x02,0x01,0x01,0x03,0x03,0x00 }, mxf_read_partition_pack },
     { { 0x06,0x0e,0x2b,0x34,0x02,0x05,0x01,0x01,0x0d,0x01,0x02,0x01,0x01,0x03,0x04,0x00 }, mxf_read_partition_pack },
+    { { 0x06,0x0e,0x2b,0x34,0x02,0x05,0x01,0x01,0x0d,0x01,0x02,0x01,0x01,0x03,0x11,0x00 }, mxf_read_partition_pack },
     { { 0x06,0x0e,0x2b,0x34,0x02,0x05,0x01,0x01,0x0d,0x01,0x02,0x01,0x01,0x04,0x02,0x00 }, mxf_read_partition_pack },
     { { 0x06,0x0e,0x2b,0x34,0x02,0x05,0x01,0x01,0x0d,0x01,0x02,0x01,0x01,0x04,0x04,0x00 }, mxf_read_partition_pack },
     { { 0x06,0x0e,0x2b,0x34,0x02,0x53,0x01,0x01,0x0d,0x01,0x01,0x01,0x01,0x01,0x2f,0x00 }, mxf_read_preface_metadata },
@@ -3200,6 +3256,9 @@ static const MXFMetadataReadTableEntry mxf_metadata_read_table[] = {
     { { 0x06,0x0e,0x2b,0x34,0x02,0x53,0x01,0x01,0x0d,0x01,0x04,0x01,0x02,0x02,0x00,0x00 }, mxf_read_cryptographic_context, sizeof(MXFCryptoContext), CryptoContext },
     { { 0x06,0x0e,0x2b,0x34,0x02,0x53,0x01,0x01,0x0d,0x01,0x02,0x01,0x01,0x10,0x01,0x00 }, mxf_read_index_table_segment, sizeof(MXFIndexTableSegment), IndexTableSegment },
     { { 0x06,0x0e,0x2b,0x34,0x02,0x53,0x01,0x01,0x0d,0x01,0x01,0x01,0x01,0x01,0x23,0x00 }, mxf_read_essence_container_data, sizeof(MXFEssenceContainerData), EssenceContainerData },
+    { { 0x06,0x0e,0x2b,0x34,0x02,0x53,0x01,0x05,0x0e,0x09,0x06,0x07,0x01,0x01,0x01,0x03 }, mxf_read_phdr_metadata_track_sub_descriptor, sizeof(MXFPHDRMetadataTrackSubDescriptor), PHDRMetadataTrackSubDescriptor },
+    { { 0x06,0x0e,0x2b,0x34,0x01,0x01,0x01,0x0c,0x0d,0x01,0x05,0x09,0x01,0x00,0x00,0x00 }, mxf_read_phdr_dovi_global_metadata, sizeof(MXFPHDRDoViGlobalMetadata), PHDRDoViGlobalData },
+
     { { 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 }, NULL, 0, AnyType },
 };
 
@@ -3225,6 +3284,10 @@ static int mxf_read_local_tags(MXFContext *mxf, KLVPacket *klv, MXFMetadataReadF
     uint64_t klv_end = avio_tell(pb) + klv->length;
     MXFMetadataSet *meta;
     void *ctx;
+
+    if (type == PHDRMetadataTrackSubDescriptor) {
+        av_log(mxf->fc, AV_LOG_TRACE, "attempt to read phdr\n");
+    }
 
     if (ctx_size) {
         meta = av_mallocz(ctx_size);
@@ -3731,7 +3794,7 @@ static int mxf_read_header(AVFormatContext *s)
             }
         }
         if (!metadata->read) {
-            av_log(s, AV_LOG_VERBOSE, "Dark key " PRIxUID "\n",
+            av_log(s, AV_LOG_VERBOSE, "testing Dark key " PRIxUID "\n",
                             UID_ARG(klv.key));
             avio_skip(s->pb, klv.length);
         }
@@ -4219,6 +4282,9 @@ static int mxf_read_seek(AVFormatContext *s, int stream_index, int64_t sample_ti
 static const AVOption options[] = {
     { "eia608_extract", "extract eia 608 captions from s436m track",
       offsetof(MXFContext, eia608_extract), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1,
+      AV_OPT_FLAG_DECODING_PARAM },
+    { "dovi_metadata_extract", "extract Dolby Vision metadata",
+      offsetof(MXFContext, dovi_metadata_extract), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1,
       AV_OPT_FLAG_DECODING_PARAM },
     { NULL },
 };

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -2487,8 +2487,9 @@ static int mxf_init_dovi_metadata_stream(MXFContext* mxf, AVStream* st)
         return AVERROR_INVALIDDATA;
     }
 
-    ret = av_dict_set(&st->metadata, "dovi_global_metadata", mxf->dovi_global_metadata->data, 0 /* flags */);
-    return ret;
+    //ret = av_dict_set(&st->metadata, "dovi_global_metadata", mxf->dovi_global_metadata->data, 0 /* flags */);
+    //return ret;
+    return 0
 }
 
 static int mxf_add_dovi_metadata_stream(MXFContext* mxf)

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -322,9 +322,9 @@ typedef struct MXFContext {
     int nb_index_tables;
     MXFIndexTable *index_tables;
     int eia608_extract;
-    int dovi_metadata_extract;
-    int dovi_metadata_stream_index;
-    MXFPHDRDoViGlobalMetadata *dovi_global_metadata;
+    int dovi_metadata_extract; /**< Boolean flag to enable extraction of metadata */
+    int dovi_metadata_stream_index; /**< Non-negative integer when a metadata stream (per-frame data) is detected */
+    MXFPHDRDoViGlobalMetadata *dovi_global_metadata; /**< Pointer to cached global metadata */
 } MXFContext;
 
 /* NOTE: klv_offset is not set (-1) for local keys */
@@ -383,7 +383,6 @@ static const uint8_t mxf_phdr_image_metadata_item[]             = { 0x06,0x0e,0x
 static const uint8_t mxf_phdr_data_definition[]                 = { 0x06,0x0e,0x2b,0x34,0x01,0x01,0x01,0x05,0x0e,0x09,0x06,0x07,0x01,0x01,0x01,0x04 };
 static const uint8_t mxf_phdr_source_track_id[]                 = { 0x06,0x0e,0x2b,0x34,0x01,0x01,0x01,0x05,0x0e,0x09,0x06,0x07,0x01,0x01,0x01,0x05 };
 static const uint8_t mxf_phdr_simple_payload_sid[]              = { 0x06,0x0e,0x2b,0x34,0x01,0x01,0x01,0x05,0x0e,0x09,0x06,0x07,0x01,0x01,0x01,0x06 };
-static const uint8_t mxf_phdr_dovi_global_metadata[]            = { 0x06,0x0e,0x2b,0x34,0x01,0x01,0x01,0x0c,0x0d,0x01,0x05,0x09,0x01,0x00,0x00,0x00 };
 
 #define IS_KLV_KEY(x, y) (!memcmp(x, y, sizeof(y)))
 
@@ -2453,6 +2452,7 @@ static MXFTrack* mxf_get_dovi_metadata_track(MXFContext* mxf)
     MXFTrack* dovi_metadata_track = NULL;
     int64_t track_id = -1;
 
+    // Obtain PHDR Metadata track information
     for (size_t k = 0; k < mxf->metadata_sets_count; k++) {
         MXFMetadataSet *metadata = mxf->metadata_sets[k];
         if (metadata->type == PHDRMetadataTrackSubDescriptor) {
@@ -2466,6 +2466,7 @@ static MXFTrack* mxf_get_dovi_metadata_track(MXFContext* mxf)
         return NULL;
     }
 
+    // Obtain the actual MXF track containing presumed Dolby Vision metadata, based on mapped track ID
     for (size_t k = 0; k < mxf->metadata_sets_count; k++) {
         MXFMetadataSet *metadata = mxf->metadata_sets[k];
         if (metadata->type == Track && (track_id == ((MXFTrack*)(metadata))->track_id)) {
@@ -2518,9 +2519,10 @@ static int mxf_add_dovi_metadata_stream(MXFContext* mxf)
         return AVERROR_INVALIDDATA;
     }
 
+    // Create a data stream which can be consumed by a client to obtain per-frame metadata
     st = avformat_new_stream(mxf->fc, NULL);
     if (!st) {
-        av_log(mxf->fc, AV_LOG_ERROR, "could not allocate DoVi metadata stream\n");
+        av_log(mxf->fc, AV_LOG_ERROR, "could not allocate Dolby Vision metadata stream\n");
         return AVERROR(ENOMEM);
     }
 
@@ -2551,9 +2553,10 @@ static int mxf_add_dovi_metadata_stream(MXFContext* mxf)
     st->priv_data = track;
 
     if (mxf_init_dovi_metadata_stream(mxf, st)) {
-        av_log(mxf->fc, AV_LOG_ERROR, "failed to fully initialize DoVi metadata stream\n");
+        av_log(mxf->fc, AV_LOG_ERROR, "failed to fully initialize Dolby Vision metadata stream\n");
     }
 
+    // Cache stream index to make per-packet processing easier later on
     mxf->dovi_metadata_stream_index = st->index;
     return 0;
 }

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -283,6 +283,7 @@ typedef struct MXFPHDRDoViGlobalMetadata {
     size_t length;
     char* data;
 } MXFPHDRDoViGlobalMetadata;
+// TODO need to free "data" when the context is destroyed
 
 /* decoded index table */
 typedef struct MXFIndexTable {
@@ -323,6 +324,7 @@ typedef struct MXFContext {
     MXFIndexTable *index_tables;
     int eia608_extract;
     int dovi_metadata_extract;
+    int dovi_metadata_stream_index;
 } MXFContext;
 
 /* NOTE: klv_offset is not set (-1) for local keys */
@@ -377,13 +379,14 @@ static const uint8_t mxf_mastering_display_uls[4][16] = {
 };
 
 static const uint8_t mxf_phdr_image_metadata_wrapping_frame[]   = { 0x06,0x0e,0x2b,0x34,0x04,0x01,0x01,0x05,0x0e,0x09,0x06,0x07,0x01,0x01,0x01,0x01 };
-static const uint8_t mxf_phdr_image_metadata_item[]             = { 0x06,0x0e,0x2b,0x34,0x01,0x02,0x01,0x05,0x0e,0x09,0x06,0x07,0x01,0x01,0x01,0x00 };
+static const uint8_t mxf_phdr_image_metadata_item[]             = { 0x06,0x0e,0x2b,0x34,0x01,0x02,0x01,0x05,0x0e,0x09,0x06,0x07,0x01,0x01,0x01,0x03 };
 static const uint8_t mxf_phdr_data_definition[]                 = { 0x06,0x0e,0x2b,0x34,0x01,0x01,0x01,0x05,0x0e,0x09,0x06,0x07,0x01,0x01,0x01,0x04 };
 static const uint8_t mxf_phdr_source_track_id[]                 = { 0x06,0x0e,0x2b,0x34,0x01,0x01,0x01,0x05,0x0e,0x09,0x06,0x07,0x01,0x01,0x01,0x05 };
 static const uint8_t mxf_phdr_simple_payload_sid[]              = { 0x06,0x0e,0x2b,0x34,0x01,0x01,0x01,0x05,0x0e,0x09,0x06,0x07,0x01,0x01,0x01,0x06 };
 static const uint8_t mxf_phdr_dovi_global_metadata[]            = { 0x06,0x0e,0x2b,0x34,0x01,0x01,0x01,0x0c,0x0d,0x01,0x05,0x09,0x01,0x00,0x00,0x00 };
 
 #define IS_KLV_KEY(x, y) (!memcmp(x, y, sizeof(y)))
+
 
 static void mxf_free_metadataset(MXFMetadataSet **ctx, int freectx)
 {
@@ -427,6 +430,10 @@ static void mxf_free_metadataset(MXFMetadataSet **ctx, int freectx)
         av_freep(&seg->temporal_offset_entries);
         av_freep(&seg->flag_entries);
         av_freep(&seg->stream_offset_entries);
+        break;
+    case PHDRDoViGlobalData:
+        av_freep(&((MXFPHDRDoViGlobalMetadata*)*ctx)->data);
+        break;
     default:
         break;
     }
@@ -1620,6 +1627,7 @@ static const MXFCodecUL mxf_data_essence_container_uls[] = {
     { { 0x06,0x0e,0x2b,0x34,0x04,0x01,0x01,0x09,0x0d,0x01,0x03,0x01,0x02,0x0d,0x00,0x00 }, 16, AV_CODEC_ID_NONE,      "vbi_smpte_436M", 11 },
     { { 0x06,0x0e,0x2b,0x34,0x04,0x01,0x01,0x09,0x0d,0x01,0x03,0x01,0x02,0x0e,0x00,0x00 }, 16, AV_CODEC_ID_NONE, "vbi_vanc_smpte_436M", 11 },
     { { 0x06,0x0e,0x2b,0x34,0x04,0x01,0x01,0x09,0x0d,0x01,0x03,0x01,0x02,0x13,0x01,0x01 }, 16, AV_CODEC_ID_TTML },
+    { { 0x06,0x0e,0x2b,0x34,0x01,0x02,0x01,0x05,0x0e,0x09,0x06,0x07,0x01,0x01,0x01,0x00 }, 16, AV_CODEC_ID_FFMETADATA, "dovi_metadata"},
     { { 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 },  0, AV_CODEC_ID_NONE },
 };
 
@@ -2443,6 +2451,98 @@ static int mxf_add_metadata_stream(MXFContext *mxf, MXFTrack *track)
     return 0;
 }
 
+static MXFTrack* mxf_get_dovi_metadata_track(MXFContext* mxf)
+{
+    MXFTrack* dovi_metadata_track = NULL;
+    int64_t track_id = -1;
+
+    for (size_t k = 0; k < mxf->metadata_sets_count; k++) {
+        MXFMetadataSet *metadata = mxf->metadata_sets[k];
+        if (metadata->type == PHDRMetadataTrackSubDescriptor) {
+            track_id = ((MXFPHDRMetadataTrackSubDescriptor*)metadata)->source_track_id;
+            break;
+        }
+    }
+
+    if (-1 == track_id) {
+        // No interleaved Dolby Vision metadata exists
+        return NULL;
+    }
+
+    for (size_t k = 0; k < mxf->metadata_sets_count; k++) {
+        MXFMetadataSet *metadata = mxf->metadata_sets[k];
+        if (metadata->type == Track && (track_id == ((MXFTrack*)(metadata))->track_id)) {
+            dovi_metadata_track = (MXFTrack*)metadata;
+            break;
+        }
+    }
+
+    av_log(NULL, AV_LOG_TRACE, "found in use Dolby Vision metadata track id %" PRIu64 "\n", track_id);
+    return dovi_metadata_track;
+}
+
+static void mxf_add_dovi_metadata_track(MXFContext* mxf)
+{
+    MXFTrack* track = NULL;
+    MXFStructuralComponent *component = NULL;
+    const MXFCodecUL *container_ul = NULL;
+    AVStream *st = NULL;
+
+    if (!(track = mxf_get_dovi_metadata_track(mxf))) {
+        return;
+    }
+
+    if (!(track->sequence = mxf_resolve_strong_ref(mxf, &track->sequence_ref, Sequence))) {
+        av_log(mxf->fc, AV_LOG_ERROR, "could not resolve material track sequence strong ref\n");
+        return;
+    }
+
+    for (size_t j = 0; j < track->sequence->structural_components_count; j++) {
+        component = mxf_resolve_sourceclip(mxf, &track->sequence->structural_components_refs[j]);
+        if (component) {
+            break;
+        }
+    }
+    if (!component)
+        return;
+
+    st = avformat_new_stream(mxf->fc, NULL);
+    if (!st) {
+        av_log(mxf->fc, AV_LOG_ERROR, "could not allocate DoVi metadata stream\n");
+        return;
+    }
+
+    st->codecpar->codec_type = AVMEDIA_TYPE_DATA;
+    st->codecpar->codec_id = AV_CODEC_ID_NONE;
+    st->id = track->track_id;
+
+    if (track->name && track->name[0]) {
+        av_dict_set(&st->metadata, "track_name", track->name, 0);
+    }
+
+    PRINT_KEY(mxf->fc, "essence container ul", track->sequence->data_definition_ul);
+    container_ul = mxf_get_codec_ul(mxf_data_essence_container_uls, &track->sequence->data_definition_ul);
+    if (container_ul->desc) {
+        av_dict_set(&st->metadata, "data_type", container_ul->desc, 0);
+    }
+
+    av_log(NULL, AV_LOG_TRACE, "added in use Dolby Vision metadata track id %u\n", track->track_id);
+
+    if (track->edit_rate.num <= 0 ||
+        track->edit_rate.den <= 0) {
+        av_log(mxf->fc, AV_LOG_WARNING,
+                "Invalid edit rate (%d/%d) found on stream #%d, "
+                "defaulting to 25/1\n",
+                track->edit_rate.num,
+                track->edit_rate.den, st->index);
+        track->edit_rate = (AVRational){25, 1};
+    }
+    avpriv_set_pts_info(st, 64, track->edit_rate.den, track->edit_rate.num);
+
+    st->priv_data = track;
+    mxf->dovi_metadata_stream_index = st->index;
+}
+
 static enum AVColorRange mxf_get_color_range(MXFContext *mxf, MXFDescriptor *descriptor)
 {
     if (descriptor->black_ref_level || descriptor->white_ref_level || descriptor->color_range) {
@@ -3208,8 +3308,13 @@ static int mxf_read_phdr_dovi_global_metadata(void *arg, AVIOContext *pb, int ta
 
     read_res = avio_read(pb, phdr_dovi_global_metadata->data, size);
 
-    av_log(NULL, AV_LOG_TRACE, "PHDR global data: read result %d, read %zu bytes\n", read_res, phdr_dovi_global_metadata->length);
-    av_log(NULL, AV_LOG_TRACE, "PHDR global data body: %s", phdr_dovi_global_metadata->data);
+    if (read_res >= 0) {
+        av_log(NULL, AV_LOG_TRACE, "PHDR global data: read %d bytes\n", read_res);
+        av_log(NULL, AV_LOG_TRACE, "PHDR global data body: %s", phdr_dovi_global_metadata->data);
+    }
+    else {
+        av_log(NULL, AV_LOG_TRACE, "Failed to read PHDR global data: result %d\n", read_res);
+    }
     return read_res;
 }
 
@@ -3811,6 +3916,8 @@ static int mxf_read_header(AVFormatContext *s)
     if ((ret = mxf_parse_structural_metadata(mxf)) < 0)
         return ret;
 
+    mxf_add_dovi_metadata_track(mxf);
+
     for (int i = 0; i < s->nb_streams; i++)
         mxf_handle_missing_index_segment(mxf, s->streams[i]);
 
@@ -3991,6 +4098,7 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
     while (1) {
         int64_t max_data_size;
         int64_t pos = avio_tell(s->pb);
+        int64_t is_phdr = 0;
 
         if (pos < mxf->current_klv_data.next_klv - mxf->current_klv_data.length || pos >= mxf->current_klv_data.next_klv) {
             mxf->current_klv_data = (KLVPacket){{0}};
@@ -4015,9 +4123,10 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
         }
         if (IS_KLV_KEY(klv.key, mxf_essence_element_key) ||
             IS_KLV_KEY(klv.key, mxf_canopus_essence_element_key) ||
-            IS_KLV_KEY(klv.key, mxf_avid_essence_element_key)) {
+            IS_KLV_KEY(klv.key, mxf_avid_essence_element_key) ||
+            (is_phdr = IS_KLV_KEY(klv.key, mxf_phdr_image_metadata_item))) {
             int body_sid = find_body_sid_by_absolute_offset(mxf, klv.offset);
-            int index = mxf_get_stream_index(s, &klv, body_sid);
+            int index = is_phdr ? mxf->dovi_metadata_stream_index : mxf_get_stream_index(s, &klv, body_sid);
             int64_t next_ofs;
             AVStream *st;
             MXFTrack *track;


### PR DESCRIPTION
Extract Prototype HDR metdata from MXF containers.

This format was developed jointly by Dolby and CineCert and is documented by Dolby as a means to carry Dolby Vision metadata.  

Global metadata (eg. mastering/target display information) is embedded once within an MXF file and is presented to the libav client as stream metadata.

Shot (or "frame") metadata is interleaved with the picture essence data and is presented to the to the libav client as a unique stream containing data packets.