### PR TITLE
Attach PHDR metadata as AVPacket side data

### DIFF
--- a/libavformat/imfdec.c
+++ b/libavformat/imfdec.c
@@ -637,7 +637,6 @@ static int imf_read_header(AVFormatContext *s)
     IMFContext *c = s->priv_data;
     char *asset_map_path;
     char *tmp_str;
-    uint8_t *dovi_opt;
     int ret = 0;
 
     c->interrupt_callback = &s->interrupt_callback;

--- a/libavformat/imfdec.c
+++ b/libavformat/imfdec.c
@@ -121,6 +121,7 @@ typedef struct IMFContext {
     char *asset_map_paths;
     AVIOInterruptCB *interrupt_callback;
     AVDictionary *avio_opts;
+    AVDictionary *mxf_format_options;
     FFIMFCPL *cpl;
     IMFAssetLocatorMap asset_locator_map;
     uint32_t track_count;
@@ -387,6 +388,9 @@ static int open_track_resource_context(AVFormatContext *s,
     if ((ret = av_dict_copy(&opts, c->avio_opts, 0)) < 0)
         goto cleanup;
 
+    if ((ret = av_dict_copy(&opts, c->mxf_format_options, 0)) < 0)
+        goto cleanup;
+
     ret = avformat_open_input(&track_resource->ctx,
                               track_resource->locator->absolute_uri,
                               NULL,
@@ -633,6 +637,7 @@ static int imf_read_header(AVFormatContext *s)
     IMFContext *c = s->priv_data;
     char *asset_map_path;
     char *tmp_str;
+    uint8_t *dovi_opt;
     int ret = 0;
 
     c->interrupt_callback = &s->interrupt_callback;
@@ -646,6 +651,17 @@ static int imf_read_header(AVFormatContext *s)
 
     if ((ret = ffio_copy_url_options(s->pb, &c->avio_opts)) < 0)
         return ret;
+
+    if (av_opt_get(s->pb, "dovi_metadata_extract", AV_OPT_SEARCH_CHILDREN, &dovi_opt) >= 0) {
+        if (dovi_opt[0] != '\0') {
+            ret = av_dict_set(&c->avio_opts, "dovi_metadata_extract", dovi_opt, AV_DICT_DONT_STRDUP_VAL);
+            if (ret < 0) {
+                return ret;
+            } else {
+                av_freep(&dovi_opt);
+            }
+        }
+    }
 
     av_log(s, AV_LOG_DEBUG, "start parsing IMF CPL: %s\n", s->url);
 
@@ -990,6 +1006,14 @@ static const AVOption imf_options[] = {
         .type        = AV_OPT_TYPE_STRING,
         .default_val = {.str = NULL},
         .flags       = AV_OPT_FLAG_DECODING_PARAM,
+    },
+    {
+        .name        = "mxf_format_options",
+        .help        = "Set options for internal MXF demuxer",
+        .offset      = offsetof(IMFContext, mxf_format_options),
+        .type        = AV_OPT_TYPE_DICT,
+        .default_val = {.str = NULL},
+        .flags      = AV_OPT_FLAG_DECODING_PARAM,
     },
     {NULL},
 };

--- a/libavformat/imfdec.c
+++ b/libavformat/imfdec.c
@@ -652,17 +652,6 @@ static int imf_read_header(AVFormatContext *s)
     if ((ret = ffio_copy_url_options(s->pb, &c->avio_opts)) < 0)
         return ret;
 
-    if (av_opt_get(s->pb, "dovi_metadata_extract", AV_OPT_SEARCH_CHILDREN, &dovi_opt) >= 0) {
-        if (dovi_opt[0] != '\0') {
-            ret = av_dict_set(&c->avio_opts, "dovi_metadata_extract", dovi_opt, AV_DICT_DONT_STRDUP_VAL);
-            if (ret < 0) {
-                return ret;
-            } else {
-                av_freep(&dovi_opt);
-            }
-        }
-    }
-
     av_log(s, AV_LOG_DEBUG, "start parsing IMF CPL: %s\n", s->url);
 
     if ((ret = ff_imf_parse_cpl(s->pb, &c->cpl)) < 0)

--- a/libavformat/imfdec.c
+++ b/libavformat/imfdec.c
@@ -585,6 +585,13 @@ static int set_context_streams_from_tracks(AVFormatContext *s)
             av_log(s, AV_LOG_ERROR, "Could not copy stream parameters\n");
             return ret;
         }
+
+        ret = av_dict_copy(&asset_stream->metadata, first_resource_stream->metadata, 0);
+        if (ret < 0) {
+            av_log(s, AV_LOG_ERROR, "Could not copy stream metadata\n");
+            return ret;
+        }
+
         avpriv_set_pts_info(asset_stream,
                             first_resource_stream->pts_wrap_bits,
                             first_resource_stream->time_base.num,

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -2521,6 +2521,7 @@ static int mxf_init_phdr_metadata_components(MXFContext* mxf)
     }
 
     mxf->valid_phdr_metadata_present = 1;
+    av_dict_set_int(&st->metadata, "dovi_frame_metadata", 1, 0 /* flags */);
 
     // The presence of global metadata is optional
     if (mxf->phdr_global_metadata && mxf->phdr_global_metadata->data) {

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -323,7 +323,8 @@ typedef struct MXFContext {
     MXFIndexTable *index_tables;
     int eia608_extract;
     int phdr_metadata_extract; /**< Boolean flag to enable extraction of metadata */
-    int phdr_metadata_stream_index; /**< Non-negative integer when a metadata stream (per-frame data) is detected */
+    //int phdr_metadata_stream_index; /**< Non-negative integer when a metadata stream (per-frame data) is detected */
+    int valid_phdr_metadata_present; /**< Boolean flag to indicate metadata stream (per-frame data) is present and valid */
     MXFPHDRGlobalMetadata *phdr_global_metadata; /**< Pointer to cached global metadata */
 } MXFContext;
 
@@ -2484,7 +2485,7 @@ static MXFTrack* mxf_get_phdr_metadata_track(MXFContext* mxf)
     return phdr_metadata_track;
 }
 
-static int mxf_add_phdr_metadata_stream(MXFContext* mxf)
+static int mxf_init_phdr_metadata_components(MXFContext* mxf)
 {
     MXFTrack* track = NULL;
     MXFStructuralComponent *component = NULL;
@@ -2501,9 +2502,11 @@ static int mxf_add_phdr_metadata_stream(MXFContext* mxf)
         return AVERROR_INVALIDDATA;
     }
     if (!mxf_match_uid(track->sequence->data_definition_ul, mxf_phdr_image_metadata_item,
-                       sizeof(mxf_phdr_image_metadata_item))) {
+                       sizeof(mxf_phdr_image_metadata_item)) &&
+        !mxf_match_uid(track->sequence->data_definition_ul, mxf_phdr_image_metadata_wrapping_frame,
+                       sizeof(mxf_phdr_image_metadata_wrapping_frame))) {
         av_log(mxf->fc, AV_LOG_ERROR,
-            "track sequence component data definitions was not PHDR image metadata item\n");
+            "track sequence component data definitions was not a PHDR image metadata item\n");
         return AVERROR_INVALIDDATA;
     }
 
@@ -2520,6 +2523,10 @@ static int mxf_add_phdr_metadata_stream(MXFContext* mxf)
         return AVERROR_INVALIDDATA;
     }
 
+    mxf->valid_phdr_metadata_present = 1;
+    av_dict_set(&mxf->fc->metadata, "dovi_global_metadata", mxf->phdr_global_metadata->data, 0 /* flags */);
+
+#if 0
     if (!mxf->phdr_global_metadata) {
         av_log(mxf->fc, AV_LOG_TRACE, "no PHDR global metadata found in metadata sets\n");
         return AVERROR_INVALIDDATA;
@@ -2561,6 +2568,7 @@ static int mxf_add_phdr_metadata_stream(MXFContext* mxf)
 
     // Cache stream index to make per-packet processing easier later on
     mxf->phdr_metadata_stream_index = st->index;
+#endif
     return 0;
 }
 
@@ -3946,7 +3954,7 @@ static int mxf_read_header(AVFormatContext *s)
         return ret;
 
     if (mxf->phdr_metadata_extract) {
-        mxf_add_phdr_metadata_stream(mxf);
+        mxf_init_phdr_metadata_components(mxf);
     }
 
     for (int i = 0; i < s->nb_streams; i++)
@@ -4157,7 +4165,7 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
             IS_KLV_KEY(klv.key, mxf_avid_essence_element_key) ||
             (is_phdr = mxf_match_uid(klv.key, mxf_phdr_image_metadata_item, sizeof(mxf_phdr_image_metadata_item-1)))) {
             int body_sid = find_body_sid_by_absolute_offset(mxf, klv.offset);
-            int index = is_phdr ? mxf->phdr_metadata_stream_index : mxf_get_stream_index(s, &klv, body_sid);
+            int index = is_phdr ? mxf->valid_phdr_metadata_present : mxf_get_stream_index(s, &klv, body_sid);
             int64_t next_ofs;
             AVStream *st;
             MXFTrack *track;

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -4219,7 +4219,7 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
                 }
                 mxf->current_klv_data = nextKlv;
                 max_data_size = nextKlv.length;
-                if (!mxf_match_uid(nextKlv.key, mxf_phdr_image_metadata_item, sizeof(mxf_phdr_image_metadata_item-1))) {
+                if (!mxf_match_uid(nextKlv.key, mxf_phdr_image_metadata_item, sizeof(mxf_phdr_image_metadata_item)-1)) {
                     av_log(s, AV_LOG_WARNING, "found J2K frame, but no PHDR metadata followed\n");
                     return AVERROR_INVALIDDATA;
                 }

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -2521,17 +2521,17 @@ static int mxf_init_phdr_metadata_components(MXFContext* mxf)
     }
 
     mxf->valid_phdr_metadata_present = 1;
-    av_dict_set_int(&st->metadata, "dovi_frame_metadata", 1, 0 /* flags */);
 
     // The presence of global metadata is optional
-    if (mxf->phdr_global_metadata && mxf->phdr_global_metadata->data) {
-        for (size_t i; i < mxf->fc->nb_streams; ++i) {
-            AVStream* st = mxf->fc->streams[i];
-            if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+    for (size_t i; i < mxf->fc->nb_streams; ++i) {
+        AVStream* st = mxf->fc->streams[i];
+        if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+            if (mxf->phdr_global_metadata && mxf->phdr_global_metadata->data) {
                 // Propagate global metadata to each stream, as it could be singularily wrapped
                 // by a higher level demuxer (eg. IMF)
                 av_dict_set(&st->metadata, "dovi_global_metadata", mxf->phdr_global_metadata->data, 0 /* flags */);
             }
+            av_dict_set_int(&st->metadata, "dovi_frame_metadata_present", 1, 0 /* flags */);
         }
     }
 
@@ -4226,7 +4226,7 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
                 // Add the accompanying metadata to the packet, with null termination
                 data = av_mallocz(nextKlv.length + 1);
                 avio_read(s->pb, data, nextKlv.length);
-                av_dict_set(&side_data_dict, "dovi_metadata", data, AV_DICT_DONT_STRDUP_VAL);
+                av_dict_set(&side_data_dict, "dovi_frame_metadata", data, AV_DICT_DONT_STRDUP_VAL);
 
                 uint8_t* packed_dict = av_packet_pack_dictionary(side_data_dict, &packed_dict_size);
                 av_dict_free(&side_data_dict);

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -4197,6 +4197,7 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
                        s->streams[index]->codecpar->codec_id == AV_CODEC_ID_JPEG2000) {
                 AVDictionary* side_data_dict = NULL;
                 char* data = NULL;
+                uint8_t* packed_dict = NULL;
                 size_t packed_dict_size = 0;
                 KLVPacket nextKlv;
 
@@ -4228,7 +4229,7 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
                 avio_read(s->pb, data, nextKlv.length);
                 av_dict_set(&side_data_dict, "dovi_frame_metadata", data, AV_DICT_DONT_STRDUP_VAL);
 
-                uint8_t* packed_dict = av_packet_pack_dictionary(side_data_dict, &packed_dict_size);
+                packed_dict = av_packet_pack_dictionary(side_data_dict, &packed_dict_size);
                 av_dict_free(&side_data_dict);
                 av_packet_add_side_data(pkt, AV_PKT_DATA_STRINGS_METADATA, packed_dict, packed_dict_size);
             }

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -4193,53 +4193,14 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
                     mxf->current_klv_data = (KLVPacket){{0}};
                     return ret;
                 }
-            } else if (mxf->phdr_metadata_extract && mxf->valid_phdr_metadata_present &&
-                       s->streams[index]->codecpar->codec_id == AV_CODEC_ID_JPEG2000) {
-                AVDictionary* side_data_dict = NULL;
-                char* data = NULL;
-                uint8_t* packed_dict = NULL;
-                size_t packed_dict_size = 0;
-                KLVPacket nextKlv;
-
-                av_log(s, AV_LOG_DEBUG, "found J2K frame with PHDR metadata\n");
-
-                // Extract the J2K frame
-                ret = av_get_packet(s->pb, pkt, klv.length);
-                if (ret < 0) {
-                    mxf->current_klv_data = (KLVPacket){{0}};
-                    return ret;
-                }
-
-                // Next immediate KLV is supposed to be a PHDR element
-                avio_seek(s->pb, klv.next_klv, SEEK_SET);
-                ret = klv_read_packet(&nextKlv, s->pb);
-                if (ret < 0) {
-                    mxf->current_klv_data = (KLVPacket){{0}};
-                    return ret;
-                }
-                mxf->current_klv_data = nextKlv;
-                max_data_size = nextKlv.length;
-                if (!mxf_match_uid(nextKlv.key, mxf_phdr_image_metadata_item, sizeof(mxf_phdr_image_metadata_item)-1)) {
-                    av_log(s, AV_LOG_WARNING, "found J2K frame, but no PHDR metadata followed\n");
-                    return AVERROR_INVALIDDATA;
-                }
-
-                // Add the accompanying metadata to the packet, with null termination
-                data = av_mallocz(nextKlv.length + 1);
-                avio_read(s->pb, data, nextKlv.length);
-                av_dict_set(&side_data_dict, "dovi_frame_metadata", data, AV_DICT_DONT_STRDUP_VAL);
-
-                packed_dict = av_packet_pack_dictionary(side_data_dict, &packed_dict_size);
-                av_dict_free(&side_data_dict);
-                av_packet_add_side_data(pkt, AV_PKT_DATA_STRINGS_METADATA, packed_dict, packed_dict_size);
-            }
-             else {
+            } else {
                 ret = av_get_packet(s->pb, pkt, klv.length);
                 if (ret < 0) {
                     mxf->current_klv_data = (KLVPacket){{0}};
                     return ret;
                 }
             }
+
             pkt->stream_index = index;
             pkt->pos = klv.offset;
 
@@ -4251,6 +4212,45 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
 
             /* seek for truncated packets */
             avio_seek(s->pb, klv.next_klv, SEEK_SET);
+
+            if (mxf->phdr_metadata_extract && mxf->valid_phdr_metadata_present &&
+                s->streams[index]->codecpar->codec_id == AV_CODEC_ID_JPEG2000) {
+                AVDictionary* side_data_dict = NULL;
+                char* data = NULL;
+                uint8_t* packed_dict = NULL;
+                size_t packed_dict_size = 0;
+                KLVPacket nextKlv;
+
+                av_log(s, AV_LOG_DEBUG, "found J2K frame, expecting PHDR metadata\n");
+
+                // Next immediate KLV is supposed to be a PHDR element
+                avio_seek(s->pb, klv.next_klv, SEEK_SET);
+                ret = klv_read_packet(&nextKlv, s->pb);
+                if (ret < 0) {
+                    mxf->current_klv_data = (KLVPacket){{0}};
+                    return ret;
+                }
+                mxf->current_klv_data = nextKlv;
+                max_data_size = nextKlv.length;
+                if (mxf_match_uid(nextKlv.key, mxf_phdr_image_metadata_item, sizeof(mxf_phdr_image_metadata_item)-1)) {
+                    // Add the accompanying metadata to the packet, with null termination
+                    data = av_mallocz(nextKlv.length + 1);
+                    avio_read(s->pb, data, nextKlv.length);
+                    av_dict_set(&side_data_dict, "dovi_frame_metadata", data, AV_DICT_DONT_STRDUP_VAL);
+
+                    packed_dict = av_packet_pack_dictionary(side_data_dict, &packed_dict_size);
+                    av_dict_free(&side_data_dict);
+                    av_packet_add_side_data(pkt, AV_PKT_DATA_STRINGS_METADATA, packed_dict, packed_dict_size);
+                    /* seek for truncated packets */
+                    avio_seek(s->pb, nextKlv.next_klv, SEEK_SET);
+                } else {
+                    // Leave next KLV for further processing next time around
+                    av_log(s, AV_LOG_WARNING, "found J2K frame, but no PHDR metadata followed\n");
+                }
+            } else {
+                /* seek for truncated packets */
+                avio_seek(s->pb, klv.next_klv, SEEK_SET);
+            }
 
             return 0;
         } else {

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -4441,7 +4441,7 @@ static const AVOption options[] = {
       offsetof(MXFContext, eia608_extract), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1,
       AV_OPT_FLAG_DECODING_PARAM },
     { "dovi_metadata_extract", "extract Dolby Vision (ie. Prototype HDR) metadata",
-      offsetof(MXFContext, phdr_metadata_extract), AV_OPT_TYPE_BOOL, {.i64 = 1}, 0, 1,
+      offsetof(MXFContext, phdr_metadata_extract), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1,
       AV_OPT_FLAG_DECODING_PARAM },
     { NULL },
 };

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -323,7 +323,6 @@ typedef struct MXFContext {
     MXFIndexTable *index_tables;
     int eia608_extract;
     int phdr_metadata_extract; /**< Boolean flag to enable extraction of metadata */
-    //int phdr_metadata_stream_index; /**< Non-negative integer when a metadata stream (per-frame data) is detected */
     int valid_phdr_metadata_present; /**< Boolean flag to indicate metadata stream (per-frame data) is present and valid */
     MXFPHDRGlobalMetadata *phdr_global_metadata; /**< Pointer to cached global metadata */
 } MXFContext;
@@ -2489,8 +2488,6 @@ static int mxf_init_phdr_metadata_components(MXFContext* mxf)
 {
     MXFTrack* track = NULL;
     MXFStructuralComponent *component = NULL;
-    const MXFCodecUL *container_ul = NULL;
-    AVStream *st = NULL;
 
     if (!(track = mxf_get_phdr_metadata_track(mxf))) {
         return 0;
@@ -2524,51 +2521,19 @@ static int mxf_init_phdr_metadata_components(MXFContext* mxf)
     }
 
     mxf->valid_phdr_metadata_present = 1;
-    av_dict_set(&mxf->fc->metadata, "dovi_global_metadata", mxf->phdr_global_metadata->data, 0 /* flags */);
 
-#if 0
-    if (!mxf->phdr_global_metadata) {
-        av_log(mxf->fc, AV_LOG_TRACE, "no PHDR global metadata found in metadata sets\n");
-        return AVERROR_INVALIDDATA;
+    // The presence of global metadata is optional
+    if (mxf->phdr_global_metadata && mxf->phdr_global_metadata->data) {
+        for (size_t i; i < mxf->fc->nb_streams; ++i) {
+            AVStream* st = mxf->fc->streams[i];
+            if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+                // Propagate global metadata to each stream, as it could be singularily wrapped
+                // by a higher level demuxer (eg. IMF)
+                av_dict_set(&st->metadata, "dovi_global_metadata", mxf->phdr_global_metadata->data, 0 /* flags */);
+            }
+        }
     }
 
-    // Create a data stream which can be consumed by a client to obtain per-frame metadata
-    st = avformat_new_stream(mxf->fc, NULL);
-    if (!st) {
-        av_log(mxf->fc, AV_LOG_ERROR, "could not allocate PHDR metadata stream\n");
-        return AVERROR(ENOMEM);
-    }
-
-    av_dict_set(&st->metadata, "dovi_global_metadata", mxf->phdr_global_metadata->data, 0 /* flags */);
-    st->codecpar->codec_type = AVMEDIA_TYPE_DATA;
-    st->codecpar->codec_id = AV_CODEC_ID_BIN_DATA;
-    st->id = track->track_id;
-
-    if (track->name && track->name[0]) {
-        av_dict_set(&st->metadata, "track_name", track->name, 0);
-    }
-    container_ul = mxf_get_codec_ul(mxf_data_essence_container_uls, &track->sequence->data_definition_ul);
-    if (container_ul->desc) {
-        av_dict_set(&st->metadata, "data_type", container_ul->desc, 0);
-    }
-
-    av_log(mxf->fc, AV_LOG_TRACE, "added in use PHDR metadata track id %u\n", track->track_id);
-    if (track->edit_rate.num <= 0 ||
-        track->edit_rate.den <= 0) {
-        av_log(mxf->fc, AV_LOG_WARNING,
-                "Invalid edit rate (%d/%d) found on stream #%d, "
-                "defaulting to 25/1\n",
-                track->edit_rate.num,
-                track->edit_rate.den, st->index);
-        track->edit_rate = (AVRational){25, 1};
-    }
-    avpriv_set_pts_info(st, 64, track->edit_rate.den, track->edit_rate.num);
-
-    st->priv_data = track;
-
-    // Cache stream index to make per-packet processing easier later on
-    mxf->phdr_metadata_stream_index = st->index;
-#endif
     return 0;
 }
 
@@ -4137,7 +4102,6 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
     while (1) {
         int64_t max_data_size;
         int64_t pos = avio_tell(s->pb);
-        int64_t is_phdr = 0;
 
         if (pos < mxf->current_klv_data.next_klv - mxf->current_klv_data.length || pos >= mxf->current_klv_data.next_klv) {
             mxf->current_klv_data = (KLVPacket){{0}};
@@ -4162,17 +4126,14 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
         }
         if (IS_KLV_KEY(klv.key, mxf_essence_element_key) ||
             IS_KLV_KEY(klv.key, mxf_canopus_essence_element_key) ||
-            IS_KLV_KEY(klv.key, mxf_avid_essence_element_key) ||
-            (is_phdr = mxf_match_uid(klv.key, mxf_phdr_image_metadata_item, sizeof(mxf_phdr_image_metadata_item-1)))) {
+            IS_KLV_KEY(klv.key, mxf_avid_essence_element_key)) {
             int body_sid = find_body_sid_by_absolute_offset(mxf, klv.offset);
-            int index = is_phdr ? mxf->valid_phdr_metadata_present : mxf_get_stream_index(s, &klv, body_sid);
+            int index = mxf_get_stream_index(s, &klv, body_sid);
+
             int64_t next_ofs;
             AVStream *st;
             MXFTrack *track;
 
-            if (is_phdr && !mxf->phdr_metadata_extract) {
-                goto skip;
-            }
             if (index < 0) {
                 av_log(s, AV_LOG_ERROR,
                        "error getting stream index %"PRIu32"\n",
@@ -4231,7 +4192,46 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
                     mxf->current_klv_data = (KLVPacket){{0}};
                     return ret;
                 }
-            } else {
+            } else if (mxf->phdr_metadata_extract && mxf->valid_phdr_metadata_present &&
+                       s->streams[index]->codecpar->codec_id == AV_CODEC_ID_JPEG2000) {
+                AVDictionary* side_data_dict = NULL;
+                char* data = NULL;
+                size_t packed_dict_size = 0;
+                KLVPacket nextKlv;
+
+                av_log(s, AV_LOG_DEBUG, "found J2K frame with PHDR metadata\n");
+
+                // Extract the J2K frame
+                ret = av_get_packet(s->pb, pkt, klv.length);
+                if (ret < 0) {
+                    mxf->current_klv_data = (KLVPacket){{0}};
+                    return ret;
+                }
+
+                // Next immediate KLV is supposed to be a PHDR element
+                avio_seek(s->pb, klv.next_klv, SEEK_SET);
+                ret = klv_read_packet(&nextKlv, s->pb);
+                if (ret < 0) {
+                    mxf->current_klv_data = (KLVPacket){{0}};
+                    return ret;
+                }
+                mxf->current_klv_data = nextKlv;
+                max_data_size = nextKlv.length;
+                if (!mxf_match_uid(nextKlv.key, mxf_phdr_image_metadata_item, sizeof(mxf_phdr_image_metadata_item-1))) {
+                    av_log(s, AV_LOG_WARNING, "found J2K frame, but no PHDR metadata followed\n");
+                    return AVERROR_INVALIDDATA;
+                }
+
+                // Add the accompanying metadata to the packet, with null termination
+                data = av_mallocz(nextKlv.length + 1);
+                avio_read(s->pb, data, nextKlv.length);
+                av_dict_set(&side_data_dict, "dovi_metadata", data, AV_DICT_DONT_STRDUP_VAL);
+
+                uint8_t* packed_dict = av_packet_pack_dictionary(side_data_dict, &packed_dict_size);
+                av_dict_free(&side_data_dict);
+                av_packet_add_side_data(pkt, AV_PKT_DATA_STRINGS_METADATA, packed_dict, packed_dict_size);
+            }
+             else {
                 ret = av_get_packet(s->pb, pkt, klv.length);
                 if (ret < 0) {
                     mxf->current_klv_data = (KLVPacket){{0}};
@@ -4440,7 +4440,7 @@ static const AVOption options[] = {
       offsetof(MXFContext, eia608_extract), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1,
       AV_OPT_FLAG_DECODING_PARAM },
     { "dovi_metadata_extract", "extract Dolby Vision (ie. Prototype HDR) metadata",
-      offsetof(MXFContext, phdr_metadata_extract), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1,
+      offsetof(MXFContext, phdr_metadata_extract), AV_OPT_TYPE_BOOL, {.i64 = 1}, 0, 1,
       AV_OPT_FLAG_DECODING_PARAM },
     { NULL },
 };

--- a/libavformat/mxfdec.c
+++ b/libavformat/mxfdec.c
@@ -4210,7 +4210,7 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
                 return ret;
             }
 
-            /* seek for truncated packets */
+            /* seek for truncated packets, effectively seeks to the next KLV */
             avio_seek(s->pb, klv.next_klv, SEEK_SET);
 
             if (mxf->phdr_metadata_extract && mxf->valid_phdr_metadata_present &&
@@ -4224,7 +4224,6 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
                 av_log(s, AV_LOG_DEBUG, "found J2K frame, expecting PHDR metadata\n");
 
                 // Next immediate KLV is supposed to be a PHDR element
-                avio_seek(s->pb, klv.next_klv, SEEK_SET);
                 ret = klv_read_packet(&nextKlv, s->pb);
                 if (ret < 0) {
                     mxf->current_klv_data = (KLVPacket){{0}};
@@ -4247,11 +4246,7 @@ static int mxf_read_packet(AVFormatContext *s, AVPacket *pkt)
                     // Leave next KLV for further processing next time around
                     av_log(s, AV_LOG_WARNING, "found J2K frame, but no PHDR metadata followed\n");
                 }
-            } else {
-                /* seek for truncated packets */
-                avio_seek(s->pb, klv.next_klv, SEEK_SET);
             }
-
             return 0;
         } else {
         skip:


### PR DESCRIPTION
The previous approach of providing an AVStream specifially for metadata did not work when the video MXF file was an asset belonging to an IMF CPL.  This is due to the fact that the IMF demuxer expects that there is only 1 stream to be consumed from an MXF file.

Instead of changing stream mappings within imfdec and perhaps breaking other things, extract the interleaved PHDR and attach it as side data to the J2K frame it belongs to.  This allows for tone mapping to be more easily applied in the future also.

