### PR TITLE
Fixed imfdec to properly pass user data context for nested inputs in …

### DIFF
--- a/libavformat/imfdec.c
+++ b/libavformat/imfdec.c
@@ -378,6 +378,7 @@ static int open_track_resource_context(AVFormatContext *s,
     track_resource->ctx->io_close = s->io_close;
     track_resource->ctx->io_close2 = s->io_close2;
     track_resource->ctx->flags |= s->flags & ~AVFMT_FLAG_CUSTOM_IO;
+    track_resource->ctx->opaque = s->opaque;
 
     if ((ret = ff_copy_whiteblacklists(track_resource->ctx, s)) < 0)
         goto cleanup;


### PR DESCRIPTION
…the AVFormatContext.opaque field.