### PR TITLE
hls/dashdec: Report segment sizes correctly

### DIFF
--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -421,7 +421,7 @@ static void free_subtitle_list(DASHContext *c)
 
 static int open_url(AVFormatContext *s, AVIOContext **pb, const char *url,
                     AVDictionary **opts, AVDictionary *opts2, int *is_http,
-                    const AVStream* stream)
+                    const AVStream* stream, uint64_t* filesize)
 {
     DASHContext *c = s->priv_data;
     AVDictionary *tmp = NULL;
@@ -429,6 +429,11 @@ static int open_url(AVFormatContext *s, AVIOContext **pb, const char *url,
     int proto_name_len;
     int ret;
     int is_proto_http = 0;
+
+    if (!filesize) {
+        return AVERROR_INVALIDDATA;
+    }
+    *filesize = UINT64_MAX;
 
     if (av_strstart(url, "crypto", NULL)) {
         if (url[6] == '+' || url[6] == ':')
@@ -487,6 +492,10 @@ static int open_url(AVFormatContext *s, AVIOContext **pb, const char *url,
     }
 
     if (is_proto_http) {
+        AVDictionaryEntry* filesize_entry = av_dict_get(tmp, "http_filesize", NULL, 0);
+        if (filesize_entry) {
+            *filesize = strtoull(filesize_entry->value, NULL, 10);
+        }
         if (s && s->http_response_code_callback) {
             AVDictionaryEntry* method_entry = av_dict_get(tmp, "http_cache_method", NULL, 0);
             AVDictionaryEntry* status_code_entry = av_dict_get(tmp, "http_cache_status_code", NULL, 0);
@@ -1790,6 +1799,7 @@ static int open_input(DASHContext *c, struct representation *pls, struct fragmen
     AVDictionary *opts = NULL;
     char *url = NULL;
     int ret = 0;
+    uint64_t filesize = 0;
 
     url = av_mallocz(c->max_url_size);
     if (!url) {
@@ -1806,7 +1816,7 @@ static int open_input(DASHContext *c, struct representation *pls, struct fragmen
 
     ff_make_absolute_url(url, MAX_URL_SIZE, c->base_url, seg->url);
 
-    // SSIMWAVE
+    /*// SSIMWAVE
     {
         AVDictionary *tmpOpts = NULL;
         URLContext* urlCtx = NULL;
@@ -1822,11 +1832,20 @@ static int open_input(DASHContext *c, struct representation *pls, struct fragmen
         av_dict_free(&tmpOpts);
         ffurl_close(urlCtx);
         av_log(NULL, AV_LOG_DEBUG, "Seg: url: %s,  size = %"PRId64"\n", url, seg->size);
-    }
+    }*/
 
     av_log(pls->parent, AV_LOG_VERBOSE, "DASH request for url '%s', offset %"PRId64"\n",
            url, seg->url_offset);
-    ret = open_url(pls->parent, &pls->input, url, &c->avio_opts, opts, NULL, pls->assoc_stream);
+
+    ret = open_url(pls->parent, &pls->input, url, &c->avio_opts, opts, NULL, pls->assoc_stream, &filesize);
+
+    if (ret >=0 && filesize != UINT64_MAX) {
+        seg->size = filesize;
+        av_log(NULL, AV_LOG_DEBUG, "Seg: url: %s, size = %"PRId64"\n", url, seg->size);
+    }
+    else {
+        seg->size = -1;
+    }
 
 cleanup:
     av_free(url);

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -153,10 +153,11 @@ typedef struct DASHContext {
     /* AdaptationSet Attribute */
     char *adaptionset_lang;
 
-// SSIMWAVE ADDITIONS
+    // SSIMWAVE ADDITIONS
     int use_timeline_segment_offset_correction;
     int fetch_completed_segments_only;
-// END SSIMWAVE ADDITIONS
+    int use_independent_segment_fetch_for_obtaining_size;
+    // END SSIMWAVE ADDITIONS
 
     int is_live;
     AVIOInterruptCB *interrupt_callback;
@@ -1816,36 +1817,42 @@ static int open_input(DASHContext *c, struct representation *pls, struct fragmen
 
     ff_make_absolute_url(url, MAX_URL_SIZE, c->base_url, seg->url);
 
-    /*// SSIMWAVE
-    {
-        AVDictionary *tmpOpts = NULL;
-        URLContext* urlCtx = NULL;
-
-        av_dict_copy(&tmpOpts, c->avio_opts, 0);
-        // Calculating Segment Size (in Bytes). Using ffurl_seek is much faster than avio_size
-        if (ffurl_open_whitelist(&urlCtx, url, 0, NULL, &tmpOpts, NULL, NULL, NULL) >= 0) {
-            seg->size = ffurl_seek(urlCtx, 0, AVSEEK_SIZE);
-        }
-        else {
-            seg->size = -1;
-        }
-        av_dict_free(&tmpOpts);
-        ffurl_close(urlCtx);
-        av_log(NULL, AV_LOG_DEBUG, "Seg: url: %s,  size = %"PRId64"\n", url, seg->size);
-    }*/
-
     av_log(pls->parent, AV_LOG_VERBOSE, "DASH request for url '%s', offset %"PRId64"\n",
            url, seg->url_offset);
 
     ret = open_url(pls->parent, &pls->input, url, &c->avio_opts, opts, NULL, pls->assoc_stream, &filesize);
 
-    if (ret >=0 && filesize != UINT64_MAX) {
-        seg->size = filesize;
-        av_log(NULL, AV_LOG_DEBUG, "Seg: url: %s, size = %"PRId64"\n", url, seg->size);
-    }
-    else {
+    if (ret >= 0) {
+        if (c->use_independent_segment_fetch_for_obtaining_size) {
+            // Download to get the actual size of the segment
+            AVDictionary *tmpOpts = NULL;
+            URLContext* urlCtx = NULL;
+
+            av_dict_copy(&tmpOpts, c->avio_opts, 0);
+            // Calculating Segment Size (in Bytes). Using ffurl_seek is much faster than avio_size
+            if (ffurl_open_whitelist(&urlCtx, url, 0, NULL, &tmpOpts, NULL, NULL, NULL) >= 0) {
+                seg->size = ffurl_seek(urlCtx, 0, AVSEEK_SIZE);
+            }
+            else {
+                seg->size = -1;
+            }
+            av_dict_free(&tmpOpts);
+            ffurl_close(urlCtx);
+        }
+        else if (filesize != UINT64_MAX) {
+            // Use size reported by HTTP module, if available
+            seg->size = filesize;
+        }
+        else {
+            // Unknown
+            seg->size = -1;
+        }
+    } else {
         seg->size = -1;
     }
+
+    av_log(pls->parent, AV_LOG_DEBUG, "Segment %s, size %ld, initial download %s\n",
+        url, seg->size, ret >= 0 ? "successful" : "failed");
 
 cleanup:
     av_free(url);
@@ -2557,6 +2564,8 @@ static const AVOption dash_options[] = {
         OFFSET(selected_video_rep_id), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = FLAGS},
     { "selected_audio_rep_id", "Audio represention ID to filter on",
         OFFSET(selected_audio_rep_id), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = FLAGS},
+    { "use_independent_segment_fetch_for_obtaining_size", "Use patch for obtaining segment size (ie. double download)",
+        OFFSET(use_independent_segment_fetch_for_obtaining_size), AV_OPT_TYPE_BOOL, {.i64 = 1}, 0, 1, FLAGS},
     {NULL}
 };
 

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -2565,7 +2565,7 @@ static const AVOption dash_options[] = {
     { "selected_audio_rep_id", "Audio represention ID to filter on",
         OFFSET(selected_audio_rep_id), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = FLAGS},
     { "use_independent_segment_fetch_for_obtaining_size", "Use patch for obtaining segment size (ie. double download)",
-        OFFSET(use_independent_segment_fetch_for_obtaining_size), AV_OPT_TYPE_BOOL, {.i64 = 1}, 0, 1, FLAGS},
+        OFFSET(use_independent_segment_fetch_for_obtaining_size), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, FLAGS},
     {NULL}
 };
 

--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -712,13 +712,18 @@ static int open_url_keepalive(AVFormatContext *s, AVIOContext **pb,
 
 static int open_url(AVFormatContext *s, AVIOContext **pb, const char *url,
                     AVDictionary **opts, AVDictionary *opts2, int *is_http_out,
-                    const AVStream** streams, size_t num_streams)
+                    const AVStream** streams, size_t num_streams, uint64_t* filesize)
 {
     HLSContext *c = s->priv_data;
     AVDictionary *tmp = NULL;
     const char *proto_name = NULL;
     int ret;
     int is_http = 0;
+
+    if (!filesize) {
+        return AVERROR_INVALIDDATA;
+    }
+    *filesize = UINT64_MAX;
 
     if (av_strstart(url, "crypto", NULL)) {
         if (url[6] == '+' || url[6] == ':')
@@ -794,6 +799,10 @@ static int open_url(AVFormatContext *s, AVIOContext **pb, const char *url,
         *is_http_out = is_http;
 
     if (is_http) {
+        AVDictionaryEntry* filesize_entry = av_dict_get(tmp, "http_filesize", NULL, 0);
+        if (filesize_entry) {
+            *filesize = strtoull(filesize_entry->value, NULL, 10);
+        }
         if (s && s->http_response_code_callback) {
             AVDictionaryEntry* method_entry = av_dict_get(tmp, "http_cache_method", NULL, 0);
             AVDictionaryEntry* status_code_entry = av_dict_get(tmp, "http_cache_status_code", NULL, 0);
@@ -1371,6 +1380,7 @@ static int open_input(HLSContext *c, struct playlist *pls, struct segment *seg, 
     AVDictionary *opts = NULL;
     int ret;
     int is_http = 0;
+    int64_t filesize = UINT64_MAX;
 
     if (c->http_persistent)
         av_dict_set(&opts, "multiple_requests", "1", 0);
@@ -1388,7 +1398,7 @@ static int open_input(HLSContext *c, struct playlist *pls, struct segment *seg, 
     if (seg->key_type == KEY_AES_128 || seg->key_type == KEY_SAMPLE_AES) {
         if (strcmp(seg->key, pls->key_url)) {
             AVIOContext *pb = NULL;
-            if (open_url(pls->parent, &pb, seg->key, &c->avio_opts, opts, NULL, pls->main_streams, pls->n_main_streams) == 0) {
+            if (open_url(pls->parent, &pb, seg->key, &c->avio_opts, opts, NULL, pls->main_streams, pls->n_main_streams, &filesize) == 0) {
                 ret = avio_read(pb, pls->key, sizeof(pls->key));
                 if (ret != sizeof(pls->key)) {
                     av_log(pls->parent, AV_LOG_ERROR, "Unable to read key file %s\n",
@@ -1415,13 +1425,13 @@ static int open_input(HLSContext *c, struct playlist *pls, struct segment *seg, 
         av_dict_set(&opts, "key", key, 0);
         av_dict_set(&opts, "iv", iv, 0);
 
-        ret = open_url(pls->parent, in, url, &c->avio_opts, opts, &is_http, pls->main_streams, pls->n_main_streams);
+        ret = open_url(pls->parent, in, url, &c->avio_opts, opts, &is_http, pls->main_streams, pls->n_main_streams, &filesize);
         if (ret < 0) {
             goto cleanup;
         }
         ret = 0;
     } else {
-        ret = open_url(pls->parent, in, seg->url, &c->avio_opts, opts, &is_http, pls->main_streams, pls->n_main_streams);
+        ret = open_url(pls->parent, in, seg->url, &c->avio_opts, opts, &is_http, pls->main_streams, pls->n_main_streams, &filesize);
     }
 
     /* Seek to the requested position. If this was a HTTP request, the offset
@@ -1441,6 +1451,10 @@ static int open_input(HLSContext *c, struct playlist *pls, struct segment *seg, 
             ret = seekret;
             ff_format_io_close(pls->parent, in);
         }
+    }
+
+    if (filesize != UINT64_MAX) {
+        seg->actual_size = filesize;
     }
 
 cleanup:
@@ -1644,9 +1658,6 @@ reload:
 
         v->input_read_done = 0;
         seg = current_segment(v);
-
-        // Get actual segment size
-        seg->actual_size = get_actual_segment_size(v, seg);
 
         /* load/update Media Initialization Section, if any */
         ret = update_init_section(v, seg);

--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -2716,7 +2716,7 @@ static const AVOption hls_options[] = {
         OFFSET(sample_aes_cek_location), AV_OPT_TYPE_STRING,
         {.str = ""}, 0, 0, FLAGS},
     { "use_independent_segment_fetch_for_obtaining_size", "Use patch for obtaining segment size (ie. double download)",
-        OFFSET(use_independent_segment_fetch_for_obtaining_size), AV_OPT_TYPE_BOOL, {.i64 = 1}, 0, 1, FLAGS},
+        OFFSET(use_independent_segment_fetch_for_obtaining_size), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, FLAGS},
     {NULL}
 };
 

--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -251,6 +251,7 @@ typedef struct HLSContext {
     int variant_count;
     char *sample_aes_iv;
     char *sample_aes_cek_location;
+    int use_independent_segment_fetch_for_obtaining_size;
 } HLSContext;
 
 static int64_t get_actual_segment_size(struct playlist *pls, struct segment* seg) {
@@ -266,7 +267,6 @@ static int64_t get_actual_segment_size(struct playlist *pls, struct segment* seg
     }
     ff_format_io_close(s, &pb);
     av_dict_free(&opts);
-    av_log(s, AV_LOG_DEBUG, "Segment %s, size %ld\n", seg->url, actual_size);
     return actual_size;
 }
 
@@ -1453,9 +1453,26 @@ static int open_input(HLSContext *c, struct playlist *pls, struct segment *seg, 
         }
     }
 
-    if (filesize != UINT64_MAX) {
-        seg->actual_size = filesize;
+    if (ret >= 0) {
+        if (c->use_independent_segment_fetch_for_obtaining_size) {
+            // Download to get the actual size of the segment
+            seg->actual_size = get_actual_segment_size(pls, seg);
+        }
+        else if (filesize != UINT64_MAX) {
+            // Use size reported by HTTP module, if available
+            seg->actual_size = filesize;
+        }
+        else {
+            // Unknown
+            seg->actual_size = -1;
+        }
     }
+    else {
+        seg->actual_size = -1;
+    }
+
+    av_log(pls->parent, AV_LOG_DEBUG, "Segment %s, size %ld, initial download %s\n",
+        seg->url, seg->actual_size, ret >= 0 ? "successful" : "failed");
 
 cleanup:
     av_dict_free(&opts);
@@ -2698,6 +2715,8 @@ static const AVOption hls_options[] = {
     {"sample_aes_cek_location", "URI of the location of the Sample AES stream",
         OFFSET(sample_aes_cek_location), AV_OPT_TYPE_STRING,
         {.str = ""}, 0, 0, FLAGS},
+    { "use_independent_segment_fetch_for_obtaining_size", "Use patch for obtaining segment size (ie. double download)",
+        OFFSET(use_independent_segment_fetch_for_obtaining_size), AV_OPT_TYPE_BOOL, {.i64 = 1}, 0, 1, FLAGS},
     {NULL}
 };
 

--- a/libavformat/http.c
+++ b/libavformat/http.c
@@ -199,6 +199,8 @@ static void http_add_status_data(URLContext* h, AVDictionary** dict) {
         av_dict_set(dict, "http_cache_method", s->post_data ? "POST" : "GET", 0);
     }
     av_dict_set_int(dict, "http_cache_status_code", s->http_code, 0);
+
+    av_dict_set_int(dict, "http_filesize", s->filesize, 0);
 }
 
 void ff_http_init_auth_state(URLContext *dest, const URLContext *src)


### PR DESCRIPTION
In dashdec, sometimes using the  `ffurl_open_whitelist` + `ffurl_seek` approach to obtain the segment size would result in a size of -1.

When consumption is at the live edge, the latest segment may not available yet from the origin.  There is a chance that the above method could fail (leading to size == -1) while the actual fetch to buffer the data is successful.  This leads to an inconsistent state within the demuxer.

Attempt to fix this by leveraging http's `filesize` parameter, which appears to do the right thing when "Content-Range" is used or "Transfer-Encoding" is set to chunked.