### PR TITLE
Report filesize for both http and file URLProtocol based modules

### DIFF
--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -422,7 +422,7 @@ static void free_subtitle_list(DASHContext *c)
 
 static int open_url(AVFormatContext *s, AVIOContext **pb, const char *url,
                     AVDictionary **opts, AVDictionary *opts2, int *is_http,
-                    const AVStream* stream, uint64_t* filesize)
+                    const AVStream* stream)
 {
     DASHContext *c = s->priv_data;
     AVDictionary *tmp = NULL;
@@ -430,11 +430,6 @@ static int open_url(AVFormatContext *s, AVIOContext **pb, const char *url,
     int proto_name_len;
     int ret;
     int is_proto_http = 0;
-
-    if (!filesize) {
-        return AVERROR_INVALIDDATA;
-    }
-    *filesize = UINT64_MAX;
 
     if (av_strstart(url, "crypto", NULL)) {
         if (url[6] == '+' || url[6] == ':')
@@ -493,10 +488,6 @@ static int open_url(AVFormatContext *s, AVIOContext **pb, const char *url,
     }
 
     if (is_proto_http) {
-        AVDictionaryEntry* filesize_entry = av_dict_get(tmp, "http_filesize", NULL, 0);
-        if (filesize_entry) {
-            *filesize = strtoull(filesize_entry->value, NULL, 10);
-        }
         if (s && s->http_response_code_callback) {
             AVDictionaryEntry* method_entry = av_dict_get(tmp, "http_cache_method", NULL, 0);
             AVDictionaryEntry* status_code_entry = av_dict_get(tmp, "http_cache_status_code", NULL, 0);
@@ -1804,7 +1795,6 @@ static int open_input(DASHContext *c, struct representation *pls, struct fragmen
     AVDictionary *opts = NULL;
     char *url = NULL;
     int ret = 0;
-    uint64_t filesize = 0;
 
     url = av_mallocz(c->max_url_size);
     if (!url) {
@@ -1824,8 +1814,10 @@ static int open_input(DASHContext *c, struct representation *pls, struct fragmen
     av_log(pls->parent, AV_LOG_VERBOSE, "DASH request for url '%s', offset %"PRId64"\n",
            url, seg->url_offset);
 
-    ret = open_url(pls->parent, &pls->input, url, &c->avio_opts, opts, NULL, pls->assoc_stream, &filesize);
+    ret = open_url(pls->parent, &pls->input, url, &c->avio_opts, opts, NULL, pls->assoc_stream);
 
+    // Default to unknown size, if unavailable
+    seg->size = -1;
     if (ret >= 0) {
         if (c->use_independent_segment_fetch_for_obtaining_size) {
             // Download to get the actual size of the segment
@@ -1843,16 +1835,13 @@ static int open_input(DASHContext *c, struct representation *pls, struct fragmen
             av_dict_free(&tmpOpts);
             ffurl_close(urlCtx);
         }
-        else if (filesize != UINT64_MAX) {
-            // Use size reported by HTTP module, if available
-            seg->size = filesize;
-        }
         else {
-            // Unknown
-            seg->size = -1;
+            // Use size reported by file/http module, if available
+            URLContext *urlc = ffio_geturlcontext(pls->input);
+            if (urlc && urlc->filesize_reported) {
+                seg->size = urlc->filesize;
+            }
         }
-    } else {
-        seg->size = -1;
     }
 
     av_log(pls->parent, AV_LOG_DEBUG, "Segment %s, size %ld, initial download %s\n",

--- a/libavformat/file.c
+++ b/libavformat/file.c
@@ -235,7 +235,20 @@ static int file_open(URLContext *h, const char *filename, int flags)
         return AVERROR(errno);
     c->fd = fd;
 
-    h->is_streamed = !fstat(fd, &st) && S_ISFIFO(st.st_mode);
+    h->is_streamed = 0;
+    h->filesize = 0;
+    h->filesize_reported = 0;
+    if (!fstat(fd, &st))
+    {
+        h->is_streamed = S_ISFIFO(st.st_mode);
+        if (S_ISREG(st.st_mode)) {
+            h->filesize = st.st_size;
+            h->filesize_reported = 1;
+        }
+        else {
+            h->filesize = 0;
+        }
+    }
 
     /* Buffer writes more than the default 32k to improve throughput especially
      * with networked file systems */

--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -712,18 +712,13 @@ static int open_url_keepalive(AVFormatContext *s, AVIOContext **pb,
 
 static int open_url(AVFormatContext *s, AVIOContext **pb, const char *url,
                     AVDictionary **opts, AVDictionary *opts2, int *is_http_out,
-                    const AVStream** streams, size_t num_streams, uint64_t* filesize)
+                    const AVStream** streams, size_t num_streams)
 {
     HLSContext *c = s->priv_data;
     AVDictionary *tmp = NULL;
     const char *proto_name = NULL;
     int ret;
     int is_http = 0;
-
-    if (!filesize) {
-        return AVERROR_INVALIDDATA;
-    }
-    *filesize = UINT64_MAX;
 
     if (av_strstart(url, "crypto", NULL)) {
         if (url[6] == '+' || url[6] == ':')
@@ -799,10 +794,6 @@ static int open_url(AVFormatContext *s, AVIOContext **pb, const char *url,
         *is_http_out = is_http;
 
     if (is_http) {
-        AVDictionaryEntry* filesize_entry = av_dict_get(tmp, "http_filesize", NULL, 0);
-        if (filesize_entry) {
-            *filesize = strtoull(filesize_entry->value, NULL, 10);
-        }
         if (s && s->http_response_code_callback) {
             AVDictionaryEntry* method_entry = av_dict_get(tmp, "http_cache_method", NULL, 0);
             AVDictionaryEntry* status_code_entry = av_dict_get(tmp, "http_cache_status_code", NULL, 0);
@@ -1380,7 +1371,6 @@ static int open_input(HLSContext *c, struct playlist *pls, struct segment *seg, 
     AVDictionary *opts = NULL;
     int ret;
     int is_http = 0;
-    int64_t filesize = UINT64_MAX;
 
     if (c->http_persistent)
         av_dict_set(&opts, "multiple_requests", "1", 0);
@@ -1398,7 +1388,7 @@ static int open_input(HLSContext *c, struct playlist *pls, struct segment *seg, 
     if (seg->key_type == KEY_AES_128 || seg->key_type == KEY_SAMPLE_AES) {
         if (strcmp(seg->key, pls->key_url)) {
             AVIOContext *pb = NULL;
-            if (open_url(pls->parent, &pb, seg->key, &c->avio_opts, opts, NULL, pls->main_streams, pls->n_main_streams, &filesize) == 0) {
+            if (open_url(pls->parent, &pb, seg->key, &c->avio_opts, opts, NULL, pls->main_streams, pls->n_main_streams) == 0) {
                 ret = avio_read(pb, pls->key, sizeof(pls->key));
                 if (ret != sizeof(pls->key)) {
                     av_log(pls->parent, AV_LOG_ERROR, "Unable to read key file %s\n",
@@ -1425,13 +1415,13 @@ static int open_input(HLSContext *c, struct playlist *pls, struct segment *seg, 
         av_dict_set(&opts, "key", key, 0);
         av_dict_set(&opts, "iv", iv, 0);
 
-        ret = open_url(pls->parent, in, url, &c->avio_opts, opts, &is_http, pls->main_streams, pls->n_main_streams, &filesize);
+        ret = open_url(pls->parent, in, url, &c->avio_opts, opts, &is_http, pls->main_streams, pls->n_main_streams);
         if (ret < 0) {
             goto cleanup;
         }
         ret = 0;
     } else {
-        ret = open_url(pls->parent, in, seg->url, &c->avio_opts, opts, &is_http, pls->main_streams, pls->n_main_streams, &filesize);
+        ret = open_url(pls->parent, in, seg->url, &c->avio_opts, opts, &is_http, pls->main_streams, pls->n_main_streams);
     }
 
     /* Seek to the requested position. If this was a HTTP request, the offset
@@ -1453,22 +1443,20 @@ static int open_input(HLSContext *c, struct playlist *pls, struct segment *seg, 
         }
     }
 
+    // Default to unknown size, if unavailable
+    seg->actual_size = -1;
     if (ret >= 0) {
         if (c->use_independent_segment_fetch_for_obtaining_size) {
             // Download to get the actual size of the segment
             seg->actual_size = get_actual_segment_size(pls, seg);
         }
-        else if (filesize != UINT64_MAX) {
-            // Use size reported by HTTP module, if available
-            seg->actual_size = filesize;
-        }
         else {
-            // Unknown
-            seg->actual_size = -1;
+            // Use size reported by file/http module, if available
+            URLContext *urlc = ffio_geturlcontext(pls->input);
+            if (urlc && urlc->filesize_reported) {
+                seg->actual_size = urlc->filesize;
+            }
         }
-    }
-    else {
-        seg->actual_size = -1;
     }
 
     av_log(pls->parent, AV_LOG_DEBUG, "Segment %s, size %ld, initial download %s\n",

--- a/libavformat/http.c
+++ b/libavformat/http.c
@@ -200,7 +200,8 @@ static void http_add_status_data(URLContext* h, AVDictionary** dict) {
     }
     av_dict_set_int(dict, "http_cache_status_code", s->http_code, 0);
 
-    av_dict_set_int(dict, "http_filesize", s->filesize, 0);
+    h->filesize = s->filesize;
+    h->filesize_reported = 1;
 }
 
 void ff_http_init_auth_state(URLContext *dest, const URLContext *src)

--- a/libavformat/url.h
+++ b/libavformat/url.h
@@ -49,9 +49,12 @@ typedef struct URLContext {
     const char *protocol_blacklist;
     int min_packet_size;        /**< if non zero, the stream is packetized with this min packet size */
 
-    // SSIMWAVE
+    // IMAX/SSIMWAVE
     ffurl_read_callback mpegts_parser_injection;
     void* mpegts_parser_injection_context;
+    int filesize;
+    int filesize_reported;
+    // IMAX/SSIMWAVE
 } URLContext;
 
 typedef struct URLProtocol {


### PR DESCRIPTION
Add file size into the URLContext to allow URLProtocol modules to
communicate the file size back to clients.

Implement support for file size in http and file modules, the two used
for HLS and DASH.