### PR TITLE
hls: Use filesize from correct AVIO context

### DIFF
--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -1452,7 +1452,7 @@ static int open_input(HLSContext *c, struct playlist *pls, struct segment *seg, 
         }
         else {
             // Use size reported by file/http module, if available
-            URLContext *urlc = ffio_geturlcontext(pls->input);
+            URLContext *urlc = ffio_geturlcontext(*in);
             if (urlc && urlc->filesize_reported) {
                 seg->actual_size = urlc->filesize;
             }


### PR DESCRIPTION
pls->input may not always be the current file that is being downloaded when calling open_input.  If `http_multiple` is set, then it may be pls->input_next instead.

The correct AVIOContext is also passed as a separate parameter into open_input (`in`), so use that instead.