### PR TITLE
Fix repeating segments in live MPD playback

### DIFF
--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -280,7 +280,7 @@ static int64_t get_segment_start_time_based_on_timeline(const DASHContext *c, st
 
         for (i = 0; i < pls->n_timelines; i++) {
             if (pls->timelines[i]->starttime > 0) {
-                start_time = pls->timelines[i]->starttime;
+                start_time = pls->timelines[i]->starttime; 
             }
             if (num == cur_seq_no)
                 goto finish;
@@ -1532,7 +1532,7 @@ static int64_t calc_max_seg_no(struct representation *pls, DASHContext *c)
         int i = 0;
         num = pls->first_seq_no + pls->n_timelines - 1;
         for (i = 0; i < pls->n_timelines; i++) {
-            if (pls->timelines[i]->repeat == -1) {
+            if (pls->timelines[i]->repeat == -1) { 
                 int length_of_each_segment = pls->timelines[i]->duration / pls->fragment_timescale;
                 num =  c->period_duration / length_of_each_segment;
             } else {
@@ -1586,6 +1586,10 @@ static void move_segments(struct representation *rep_src, struct representation 
 }
 
 static void fix_start_number(DASHContext* c, struct representation** old_reps, struct representation** new_reps, int n_reps, const char* label) {
+    if (!c->use_timeline_segment_offset_correction) {
+        return
+    }
+
     for (int i = 0; i < n_reps; i++) {
         struct representation *last_rep = old_reps[i];
         struct representation *new_rep = new_reps[i];
@@ -1604,32 +1608,12 @@ static void fix_start_number(DASHContext* c, struct representation** old_reps, s
             int64_t last_seq_no = calc_next_seg_no_from_timelines(c, new_rep, last_end_time * new_rep->fragment_timescale - 1);
             // TODO: calc_next_seg_no_from_timelines  returns -1 if the sequences isn't in the playlist... I think we need to die?
             int64_t new_last_seq_no = calc_max_seg_no(new_rep, c);
-            av_log(c, AV_LOG_VERBOSE, "Checking if %s start_number needes fixing, last_end_time: [%"PRId64"] last_seq_no: [%"PRId64"], new_last_seq_no: [%"PRId64"], last_start_number: [%"PRId64"], new_start_number: [%"PRId64"]\n",
+            av_log(c, AV_LOG_DEBUG, "Checking if %s start_number needes fixing, last_end_time: [%"PRId64"] last_seq_no: [%"PRId64"], new_last_seq_no: [%"PRId64"], last_start_number: [%"PRId64"], new_start_number: [%"PRId64"]\n",
                    label, last_end_time, last_seq_no, new_last_seq_no, last_rep->start_number, new_rep->start_number);
             int64_t startNumber = last_rep->start_number + (new_last_seq_no - last_seq_no);
             // Update start/first_seq_no (last_seq_no will be recalculated in move_timelines/move_segments)
-            av_log(c, AV_LOG_VERBOSE, "Fixing %s timeline. start_number: [%"PRId64"] first_seq_no: [%"PRId64"], new: [%"PRId64"]\n",
+            av_log(c, AV_LOG_DEBUG, "Fixing %s timeline. start_number: [%"PRId64"] first_seq_no: [%"PRId64"], new: [%"PRId64"]\n",
                     label, new_rep->start_number, new_rep->first_seq_no, startNumber);
-            new_rep->start_number = new_rep->first_seq_no = startNumber;
-        }
-    }
-}
-
-static void fix_start_number2(DASHContext* c, struct representation** old_reps, struct representation** new_reps, int n_reps, const char* label) {
-    for (int i = 0; i < n_reps; i++) {
-        struct representation *last_rep = old_reps[i];
-        struct representation *new_rep = new_reps[i];
-        if (!new_rep->found_start_number && new_rep->timelines && new_rep->n_timelines > 0) {
-            // The representation is using timeline mode - and has no start number hint. So try to guess the start 
-            // number by finding where the last segment in the previous version of the representation is in the current
-            // representation version. We can use this to find the number of segments which have been dropped since the
-            // representation was updated. We can then infer the new start_number based on this information, and the
-            // previous version of the representations start_number.
-            int64_t last_end_time = get_segment_start_time_based_on_timeline(c, last_rep, last_rep->last_seq_no) / last_rep->fragment_timescale;
-            int64_t last_seq_no = calc_next_seg_no_from_timelines(c, new_rep, last_end_time * new_rep->fragment_timescale - 1);
-            int64_t new_last_seq_no = calc_max_seg_no(new_rep, c);
-            int64_t startNumber = last_rep->start_number + (new_last_seq_no - last_seq_no);
-            // Update start/first_seq_no (last_seq_no will be recalculated in move_timelines/move_segments)
             new_rep->start_number = new_rep->first_seq_no = startNumber;
         }
     }
@@ -1683,8 +1667,8 @@ static int refresh_manifest(AVFormatContext *s)
      * uses the start number (and first_seq_no and last_seq_no) to perform segment selection when in timeline mode. So in the case where the playlist
      * is in timeline mode, and start_number is NOT set, we need to fix-up the start_number/first_seq_no/last_seq_no based on the segment times instead. */
     fix_start_number(c, videos, c->videos, n_videos, "video");
-    fix_start_number2(c, audios, c->audios, n_audios, "audio");
-    fix_start_number2(c, subtitles, c->subtitles, n_subtitles, "subtitles");
+    fix_start_number(c, audios, c->audios, n_audios, "audio");
+    fix_start_number(c, subtitles, c->subtitles, n_subtitles, "subtitles");
 
     /* It is possible for the demuxer to be processing at the live edge and waiting for a segment in the future.
      * When that happens 'cur_seq_no' can be past the end of the timelines indicated by the MPD.

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -97,6 +97,7 @@ struct representation {
     int64_t first_seq_no;
     int64_t last_seq_no;
     int64_t start_number; /* used in case when we have dynamic list of segment to know which segments are new one*/
+    int found_start_number;
 
     int64_t fragment_duration;
     int64_t fragment_timescale;
@@ -998,6 +999,7 @@ static int parse_manifest_representation(AVFormatContext *s, const char *url,
         val = get_val_from_nodes_tab(fragment_templates_tab, 4, "startNumber");
         if (val) {
             rep->start_number = rep->first_seq_no = (int64_t) strtoll(val, NULL, 10);
+            rep->found_start_number = 1;
             av_log(s, AV_LOG_TRACE, "rep->first_seq_no = [%"PRId64"]\n", rep->first_seq_no);
             xmlFree(val);
         }
@@ -1067,6 +1069,7 @@ static int parse_manifest_representation(AVFormatContext *s, const char *url,
         val = get_val_from_nodes_tab(segmentlists_tab, 3, "startNumber");
         if (val) {
             rep->start_number = rep->first_seq_no = (int64_t) strtoll(val, NULL, 10);
+            rep->found_start_number = 1;
             av_log(s, AV_LOG_TRACE, "rep->first_seq_no = [%"PRId64"]\n", rep->first_seq_no);
             xmlFree(val);
         }
@@ -1554,6 +1557,7 @@ static void move_timelines(struct representation *rep_src, struct representation
         free_timelines_list(rep_dest);
         rep_dest->timelines    = rep_src->timelines;
         rep_dest->n_timelines  = rep_src->n_timelines;
+        rep_dest->start_number = rep_src->start_number;
         rep_dest->first_seq_no = rep_src->first_seq_no;
         rep_dest->last_seq_no = calc_max_seg_no(rep_dest, c);
         rep_src->timelines = NULL;
@@ -1581,6 +1585,55 @@ static void move_segments(struct representation *rep_src, struct representation 
     }
 }
 
+static void fix_start_number(DASHContext* c, struct representation** old_reps, struct representation** new_reps, int n_reps, const char* label) {
+    for (int i = 0; i < n_reps; i++) {
+        struct representation *last_rep = old_reps[i];
+        struct representation *new_rep = new_reps[i];
+        if (!new_rep->found_start_number && new_rep->timelines && new_rep->n_timelines > 0) {
+            if (last_rep->last_seq_no == 0) {
+                // First load/refresh. Wait till we've properly detected a segment. We only want to fixup representations after the first
+                // load.
+                continue;
+            }
+            // The representation is using timeline mode - and has no start number hint. So try to guess the start 
+            // number by finding where the last segment in the previous version of the representation is in the current
+            // representation version. We can use this to find the number of segments which have been dropped since the
+            // representation was updated. We can then infer the new start_number based on this information, and the
+            // previous version of the representations start_number.
+            int64_t last_end_time = get_segment_start_time_based_on_timeline(c, last_rep, last_rep->last_seq_no) / last_rep->fragment_timescale;
+            int64_t last_seq_no = calc_next_seg_no_from_timelines(c, new_rep, last_end_time * new_rep->fragment_timescale - 1);
+            // TODO: calc_next_seg_no_from_timelines  returns -1 if the sequences isn't in the playlist... I think we need to die?
+            int64_t new_last_seq_no = calc_max_seg_no(new_rep, c);
+            av_log(c, AV_LOG_VERBOSE, "Checking if %s start_number needes fixing, last_end_time: [%"PRId64"] last_seq_no: [%"PRId64"], new_last_seq_no: [%"PRId64"], last_start_number: [%"PRId64"], new_start_number: [%"PRId64"]\n",
+                   label, last_end_time, last_seq_no, new_last_seq_no, last_rep->start_number, new_rep->start_number);
+            int64_t startNumber = last_rep->start_number + (new_last_seq_no - last_seq_no);
+            // Update start/first_seq_no (last_seq_no will be recalculated in move_timelines/move_segments)
+            av_log(c, AV_LOG_VERBOSE, "Fixing %s timeline. start_number: [%"PRId64"] first_seq_no: [%"PRId64"], new: [%"PRId64"]\n",
+                    label, new_rep->start_number, new_rep->first_seq_no, startNumber);
+            new_rep->start_number = new_rep->first_seq_no = startNumber;
+        }
+    }
+}
+
+static void fix_start_number2(DASHContext* c, struct representation** old_reps, struct representation** new_reps, int n_reps, const char* label) {
+    for (int i = 0; i < n_reps; i++) {
+        struct representation *last_rep = old_reps[i];
+        struct representation *new_rep = new_reps[i];
+        if (!new_rep->found_start_number && new_rep->timelines && new_rep->n_timelines > 0) {
+            // The representation is using timeline mode - and has no start number hint. So try to guess the start 
+            // number by finding where the last segment in the previous version of the representation is in the current
+            // representation version. We can use this to find the number of segments which have been dropped since the
+            // representation was updated. We can then infer the new start_number based on this information, and the
+            // previous version of the representations start_number.
+            int64_t last_end_time = get_segment_start_time_based_on_timeline(c, last_rep, last_rep->last_seq_no) / last_rep->fragment_timescale;
+            int64_t last_seq_no = calc_next_seg_no_from_timelines(c, new_rep, last_end_time * new_rep->fragment_timescale - 1);
+            int64_t new_last_seq_no = calc_max_seg_no(new_rep, c);
+            int64_t startNumber = last_rep->start_number + (new_last_seq_no - last_seq_no);
+            // Update start/first_seq_no (last_seq_no will be recalculated in move_timelines/move_segments)
+            new_rep->start_number = new_rep->first_seq_no = startNumber;
+        }
+    }
+}
 
 static int refresh_manifest(AVFormatContext *s)
 {
@@ -1625,6 +1678,14 @@ static int refresh_manifest(AVFormatContext *s)
                n_subtitles, c->n_subtitles);
         return AVERROR_INVALIDDATA;
     }
+
+    /* Some encoders will NOT include a startNumber in the segment timeline, startNumber IS optional in the spec, but the rest of the code
+     * uses the start number (and first_seq_no and last_seq_no) to perform segment selection when in timeline mode. So in the case where the playlist
+     * is in timeline mode, and start_number is NOT set, we need to fix-up the start_number/first_seq_no/last_seq_no based on the segment times instead. */
+    fix_start_number(c, videos, c->videos, n_videos, "video");
+    fix_start_number2(c, audios, c->audios, n_audios, "audio");
+    fix_start_number2(c, subtitles, c->subtitles, n_subtitles, "subtitles");
+
     /* It is possible for the demuxer to be processing at the live edge and waiting for a segment in the future.
      * When that happens 'cur_seq_no' can be past the end of the timelines indicated by the MPD.
      * The functions below that attempt to calculate the next segment number based on the timeline data will end up
@@ -1693,6 +1754,7 @@ static int get_current_fragment(struct representation *pls, struct fragment** ne
     int err = 0;
     int64_t min_seq_no = 0;
     int64_t max_seq_no = 0;
+    int64_t old_max_seq_no = 0;
     struct fragment *seg = NULL;
     struct fragment *seg_ptr = NULL;
     DASHContext *c = pls->parent->priv_data;
@@ -1725,18 +1787,26 @@ static int get_current_fragment(struct representation *pls, struct fragment** ne
     if (c->is_live) {
         min_seq_no = calc_min_seg_no(pls->parent, pls);
         max_seq_no = calc_max_seg_no(pls, c);
-
+        old_max_seq_no = max_seq_no;
         if (pls->timelines || pls->fragments) {
             err = refresh_manifest(pls->parent);
             if (AVERROR_INPUT_CHANGED == err) {
                 return err;
             }
+            min_seq_no = calc_min_seg_no(pls->parent, pls);
+            max_seq_no = calc_max_seg_no(pls, c);
         }
         if (pls->cur_seq_no < min_seq_no) {
-            av_log(pls->parent, AV_LOG_VERBOSE, "old fragment: cur[%"PRId64"] min[%"PRId64"] max[%"PRId64"]\n", (int64_t)pls->cur_seq_no, min_seq_no, max_seq_no);
+            av_log(pls->parent, AV_LOG_VERBOSE, "old fragment: cur[%"PRId64"] min[%"PRId64"] max[%"PRId64"]\n",
+                   (int64_t)pls->cur_seq_no, min_seq_no, max_seq_no);
             pls->cur_seq_no = calc_cur_seg_no(pls->parent, pls);
-        } else if (pls->cur_seq_no > max_seq_no) {
-            av_log(pls->parent, AV_LOG_VERBOSE, "new fragment: min[%"PRId64"] max[%"PRId64"]\n", min_seq_no, max_seq_no);
+        } else if (pls->cur_seq_no > old_max_seq_no) {
+            av_log(pls->parent, AV_LOG_VERBOSE, "new fragment: cur[%"PRId64"] min[%"PRId64"] max[%"PRId64"] (prev_max[%"PRId64"])\n",
+                   (int64_t)pls->cur_seq_no, min_seq_no, max_seq_no, old_max_seq_no);
+            if (pls->cur_seq_no > max_seq_no) {
+                av_log(pls->parent, AV_LOG_VERBOSE, "new fragment outside playlist availability");
+                return AVERROR(EAGAIN);
+            }
         }
         seg = av_mallocz(sizeof(struct fragment));
         if (!seg) {
@@ -1753,12 +1823,12 @@ static int get_current_fragment(struct representation *pls, struct fragment** ne
         if (!pls->url_template) {
             av_log(pls->parent, AV_LOG_ERROR, "Cannot get fragment, missing template URL\n");
             av_free(seg);
-            return NULL;
+            return 0;
         }
         tmpfilename = av_mallocz(c->max_url_size);
         if (!tmpfilename) {
             av_free(seg);
-            return NULL;
+            return 0;
         }
         ff_dash_fill_tmpl_params(tmpfilename, c->max_url_size, pls->url_template, 0, pls->cur_seq_no, 0, get_segment_start_time_based_on_timeline(c, pls, pls->cur_seq_no));
         seg->url = av_strireplace(pls->url_template, pls->url_template, tmpfilename);
@@ -1769,7 +1839,7 @@ static int get_current_fragment(struct representation *pls, struct fragment** ne
                 av_log(pls->parent, AV_LOG_ERROR, "Cannot resolve template url '%s'\n", pls->url_template);
                 av_free(tmpfilename);
                 av_free(seg);
-                return NULL;
+                return 0;
             }
         }
         av_free(tmpfilename);
@@ -1938,7 +2008,13 @@ restart:
     if (!v->input) {
         free_fragment(&v->cur_seg);
         ret = get_current_fragment(v, &v->cur_seg);
-        if (0 != ret) {
+        if (ret == AVERROR(EAGAIN)) {
+            // Fragment not ready yet, sleep and try again
+            // TODO: better retry logic, timeout after X time, etc
+            av_usleep(100*1000);
+            goto restart;
+        }
+        else if (0 != ret) {
             goto end;
         }
         if (!v->cur_seg) {
@@ -1981,7 +2057,13 @@ restart:
     /* check the v->cur_seg, if it is null, get current and double check if the new v->cur_seg*/
     if (!v->cur_seg) {
         ret = get_current_fragment(v, &v->cur_seg);
-        if (0 != ret) {
+        if (ret == AVERROR(EAGAIN)) {
+            // Fragment not ready yet, sleep and try again
+            // TODO: better retry logic, timeout after X time, etc
+            av_usleep(100*1000);
+            goto restart;
+        }
+        else if (0 != ret) {
             goto end;
         }
         if (!v->cur_seg) {

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -97,7 +97,6 @@ struct representation {
     int64_t first_seq_no;
     int64_t last_seq_no;
     int64_t start_number; /* used in case when we have dynamic list of segment to know which segments are new one*/
-    int found_start_number;
 
     int64_t fragment_duration;
     int64_t fragment_timescale;
@@ -124,6 +123,7 @@ struct representation {
 
     ffurl_read_callback mpegts_parser_input_backup;
     void* mpegts_parser_input_context_backup;
+    int found_start_number;
 };
 
 typedef struct DASHContext {
@@ -159,6 +159,8 @@ typedef struct DASHContext {
     int fetch_completed_segments_only;
     int use_independent_segment_fetch_for_obtaining_size;
     int start_on_live_edge;
+    int max_reload;
+    int reload_retry_interval;
     // END SSIMWAVE ADDITIONS
 
     int is_live;
@@ -280,7 +282,7 @@ static int64_t get_segment_start_time_based_on_timeline(const DASHContext *c, st
 
         for (i = 0; i < pls->n_timelines; i++) {
             if (pls->timelines[i]->starttime > 0) {
-                start_time = pls->timelines[i]->starttime; 
+                start_time = pls->timelines[i]->starttime;
             }
             if (num == cur_seq_no)
                 goto finish;
@@ -1532,7 +1534,7 @@ static int64_t calc_max_seg_no(struct representation *pls, DASHContext *c)
         int i = 0;
         num = pls->first_seq_no + pls->n_timelines - 1;
         for (i = 0; i < pls->n_timelines; i++) {
-            if (pls->timelines[i]->repeat == -1) { 
+            if (pls->timelines[i]->repeat == -1) {
                 int length_of_each_segment = pls->timelines[i]->duration / pls->fragment_timescale;
                 num =  c->period_duration / length_of_each_segment;
             } else {
@@ -1587,7 +1589,7 @@ static void move_segments(struct representation *rep_src, struct representation 
 
 static void fix_start_number(DASHContext* c, struct representation** old_reps, struct representation** new_reps, int n_reps, const char* label) {
     if (!c->use_timeline_segment_offset_correction) {
-        return
+        return;
     }
 
     for (int i = 0; i < n_reps; i++) {
@@ -1606,15 +1608,23 @@ static void fix_start_number(DASHContext* c, struct representation** old_reps, s
             // previous version of the representations start_number.
             int64_t last_end_time = get_segment_start_time_based_on_timeline(c, last_rep, last_rep->last_seq_no) / last_rep->fragment_timescale;
             int64_t last_seq_no = calc_next_seg_no_from_timelines(c, new_rep, last_end_time * new_rep->fragment_timescale - 1);
-            // TODO: calc_next_seg_no_from_timelines  returns -1 if the sequences isn't in the playlist... I think we need to die?
+            if (last_seq_no < 0) {
+                // Previous edge sequence is outside of the current playlist... which means that an entire timeShiftBufferDepth worth
+                // of time (or more) has passed and every segment in the playlist is new... we should be ok just restarting numbering
+                // (ie. don't do anything)
+                av_log(c, AV_LOG_WARNING, "Previous edge segment not found in manifest, discontinuity suspected. Segment numbers may be reset.\n");
+                continue;
+            }
             int64_t new_last_seq_no = calc_max_seg_no(new_rep, c);
             av_log(c, AV_LOG_DEBUG, "Checking if %s start_number needes fixing, last_end_time: [%"PRId64"] last_seq_no: [%"PRId64"], new_last_seq_no: [%"PRId64"], last_start_number: [%"PRId64"], new_start_number: [%"PRId64"]\n",
                    label, last_end_time, last_seq_no, new_last_seq_no, last_rep->start_number, new_rep->start_number);
             int64_t startNumber = last_rep->start_number + (new_last_seq_no - last_seq_no);
-            // Update start/first_seq_no (last_seq_no will be recalculated in move_timelines/move_segments)
-            av_log(c, AV_LOG_DEBUG, "Fixing %s timeline. start_number: [%"PRId64"] first_seq_no: [%"PRId64"], new: [%"PRId64"]\n",
-                    label, new_rep->start_number, new_rep->first_seq_no, startNumber);
-            new_rep->start_number = new_rep->first_seq_no = startNumber;
+            if (new_rep->start_number != startNumber) {
+                // Update start/first_seq_no (last_seq_no will be recalculated in move_timelines/move_segments)
+                av_log(c, AV_LOG_DEBUG, "Fixing %s timeline. start_number: [%"PRId64"] first_seq_no: [%"PRId64"], new: [%"PRId64"]\n",
+                        label, new_rep->start_number, new_rep->first_seq_no, startNumber);
+                new_rep->start_number = new_rep->first_seq_no = startNumber;
+            }
         }
     }
 }
@@ -1772,6 +1782,7 @@ static int get_current_fragment(struct representation *pls, struct fragment** ne
         min_seq_no = calc_min_seg_no(pls->parent, pls);
         max_seq_no = calc_max_seg_no(pls, c);
         old_max_seq_no = max_seq_no;
+
         if (pls->timelines || pls->fragments) {
             err = refresh_manifest(pls->parent);
             if (AVERROR_INPUT_CHANGED == err) {
@@ -1971,9 +1982,32 @@ static int64_t seek_data(void *opaque, int64_t offset, int whence)
     return AVERROR(ENOSYS);
 }
 
+static void delay_reload(DASHContext *c, int reload_count)
+{
+    int delay = 0;
+
+    // Attempt first reload immediately,
+    if (reload_count == 1)
+    {
+        delay = 0;
+    }
+    else if (c->reload_retry_interval < 0)
+    {
+        delay = c->minimum_update_period * 1000 * 1000 / 2;
+    }
+    else {
+        delay = c->reload_retry_interval * 1000;
+    }
+    if (delay > 0) {
+        av_log(c, AV_LOG_DEBUG, "Segment not ready, retrying again in: [%"PRId64"]ms\n", delay/1000);
+        av_usleep(delay);
+    }
+}
+
 static int read_data(void *opaque, uint8_t *buf, int buf_size)
 {
     int ret = 0;
+    int reload_count = 0;
     struct representation *v = opaque;
     DASHContext *c = v->parent->priv_data;
 
@@ -1991,11 +2025,13 @@ static int read_data(void *opaque, uint8_t *buf, int buf_size)
 restart:
     if (!v->input) {
         free_fragment(&v->cur_seg);
+        reload_count++;
+        if (reload_count > c->max_reload)
+            return AVERROR_EOF;
         ret = get_current_fragment(v, &v->cur_seg);
-        if (ret == AVERROR(EAGAIN)) {
+        if (ret == AVERROR(EAGAIN) && c->is_live) {
             // Fragment not ready yet, sleep and try again
-            // TODO: better retry logic, timeout after X time, etc
-            av_usleep(100*1000);
+            delay_reload(c, reload_count);
             goto restart;
         }
         else if (0 != ret) {
@@ -2040,11 +2076,13 @@ restart:
 
     /* check the v->cur_seg, if it is null, get current and double check if the new v->cur_seg*/
     if (!v->cur_seg) {
+        reload_count++;
+        if (reload_count > c->max_reload)
+            return AVERROR_EOF;
         ret = get_current_fragment(v, &v->cur_seg);
-        if (ret == AVERROR(EAGAIN)) {
+        if (ret == AVERROR(EAGAIN) && c->is_live) {
             // Fragment not ready yet, sleep and try again
-            // TODO: better retry logic, timeout after X time, etc
-            av_usleep(100*1000);
+            delay_reload(c, reload_count);
             goto restart;
         }
         else if (0 != ret) {
@@ -2073,7 +2111,6 @@ end:
         urlc->mpegts_parser_injection = v->mpegts_parser_input_backup;
         urlc->mpegts_parser_injection_context = v->mpegts_parser_input_context_backup;
     }
-
     return ret;
 }
 
@@ -2633,6 +2670,10 @@ static const AVOption dash_options[] = {
         OFFSET(use_independent_segment_fetch_for_obtaining_size), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, FLAGS},
     { "start_on_live_edge", "Start processing at the latest segment for live manifests",
         OFFSET(start_on_live_edge), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, FLAGS},
+    {"max_reload", "Maximum number of times a list is attempted to be reloaded during live (dynamic) playback",
+        OFFSET(max_reload), AV_OPT_TYPE_INT, {.i64 = 1000}, 0, INT_MAX, FLAGS},
+    {"reload_retry_interval", "Interval in ms to wait before retrying playlist reload. If not set, defaults to mimumumUpdatePeriod/2",
+        OFFSET(reload_retry_interval), AV_OPT_TYPE_INT, {.i64 = -1}, 0, INT_MAX, FLAGS},
     {NULL}
 };
 

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -1588,6 +1588,23 @@ static void move_segments(struct representation *rep_src, struct representation 
     }
 }
 
+static int64_t guess_start_number(DASHContext* c, struct representation* rep) {
+    int64_t duration = rep->fragment_duration;
+    int64_t startNumber = rep->start_number;
+    if (c->use_timeline_segment_offset_correction && !rep->found_start_number && rep->timelines && rep->n_timelines) {
+        // Best guess: ((wall clock time - availabilityStartTime ) / (duration / timescale ))
+        if (!duration) {
+            // The timeline segment duration can vary +/-50% between segments, but its our best guess.
+            duration = rep->timelines[0]->duration;
+        }
+        if (duration) {
+            startNumber = ((get_current_time_in_sec() - c->availability_start_time) * rep->fragment_timescale)/ (duration);
+            av_log(c, AV_LOG_DEBUG, "Guessing start_number from timeline: [%"PRId64"]", startNumber);
+        }
+    }
+    return startNumber;
+}
+
 static void fix_start_number(DASHContext* c, struct representation** old_reps, struct representation** new_reps, int n_reps, const char* label) {
     int64_t last_end_time = 0;
     int64_t last_seq_no = 0;
@@ -1602,11 +1619,6 @@ static void fix_start_number(DASHContext* c, struct representation** old_reps, s
         struct representation *last_rep = old_reps[i];
         struct representation *new_rep = new_reps[i];
         if (!new_rep->found_start_number && new_rep->timelines && new_rep->n_timelines > 0) {
-            if (last_rep->last_seq_no == 0) {
-                // First load/refresh. Wait till we've properly detected a segment. We only want to fixup representations after the first
-                // load.
-                continue;
-            }
             // The representation is using timeline mode - and has no start number hint. So try to guess the start 
             // number by finding where the last segment in the previous version of the representation is in the current
             // representation version. We can use this to find the number of segments which have been dropped since the
@@ -1616,9 +1628,16 @@ static void fix_start_number(DASHContext* c, struct representation** old_reps, s
             last_seq_no = calc_next_seg_no_from_timelines(c, new_rep, last_end_time * new_rep->fragment_timescale - 1);
             if (last_seq_no < 0) {
                 // Previous edge sequence is outside of the current playlist... which means that an entire timeShiftBufferDepth worth
-                // of time (or more) has passed and every segment in the playlist is new... we should be ok just restarting numbering
-                // (ie. don't do anything)
-                av_log(c, AV_LOG_WARNING, "Previous edge segment not found in manifest, discontinuity suspected. Segment numbers may be reset.\n");
+                // of time (or more) has passed and every segment in the playlist is new...
+                // Try to estimate the start sequence and segment number from the timeline
+                av_log(c, AV_LOG_WARNING, "Previous edge segment not found in manifest, discontinuity suspected\n");
+                new_start_number = guess_start_number(c, new_rep);
+                if (new_start_number < last_rep->last_seq_no + 1) {
+                    av_log(c, AV_LOG_DEBUG, "Fixing %s timeline. start_number: [%"PRId64"], new: [%"PRId64"]\n",
+                           label, new_rep->start_number, last_rep->last_seq_no + 1);
+                    new_start_number = last_rep->last_seq_no + 1;
+                }
+                new_rep->start_number = new_rep->first_seq_no = new_start_number;
                 continue;
             }
             new_last_seq_no = calc_max_seg_no(new_rep, c);
@@ -1627,8 +1646,8 @@ static void fix_start_number(DASHContext* c, struct representation** old_reps, s
             new_start_number = last_rep->start_number + (new_last_seq_no - last_seq_no);
             if (new_rep->start_number != new_start_number) {
                 // Update start/first_seq_no (last_seq_no will be recalculated in move_timelines/move_segments)
-                av_log(c, AV_LOG_DEBUG, "Fixing %s timeline. start_number: [%"PRId64"] first_seq_no: [%"PRId64"], new: [%"PRId64"]\n",
-                        label, new_rep->start_number, new_rep->first_seq_no, new_start_number);
+                av_log(c, AV_LOG_DEBUG, "Fixing %s timeline. start_number: [%"PRId64"], new: [%"PRId64"]\n",
+                       label, new_rep->start_number, new_start_number);
                 new_rep->start_number = new_rep->first_seq_no = new_start_number;
             }
         }
@@ -1997,7 +2016,7 @@ static void delay_reload(DASHContext *c, int64_t reload_count)
         delay = c->reload_retry_interval * 1000;
     }
     if (delay > 0) {
-        av_log(c, AV_LOG_DEBUG, "Segment not ready (reload_count: %"PRId64"), retrying again in %ldms\n", reload_count, delay/1000);
+        av_log(c, AV_LOG_DEBUG, "Segment not ready (reload_count: %"PRId64"), retrying again in %dms\n", reload_count, delay/1000);
         av_usleep(delay);
     }
 }
@@ -2205,11 +2224,14 @@ fail:
 
 static int open_demux_for_component(AVFormatContext *s, struct representation *pls)
 {
+    DASHContext *c = s->priv_data;
     int ret = 0;
     int i;
 
     pls->parent = s;
 
+    // First load/refresh... guess the start number using the timeline and duration
+    pls->start_number = pls->first_seq_no = guess_start_number(c, pls);
     if (!pls->last_seq_no) {
         pls->last_seq_no = calc_max_seg_no(pls, s->priv_data);
     }

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -1599,7 +1599,7 @@ static int64_t guess_start_number(DASHContext* c, struct representation* rep) {
         }
         if (duration) {
             startNumber = ((get_current_time_in_sec() - c->availability_start_time) * rep->fragment_timescale)/ (duration);
-            av_log(c, AV_LOG_DEBUG, "Guessing start_number from timeline: [%"PRId64"]", startNumber);
+            av_log(c, AV_LOG_DEBUG, "Guessing start_number from timeline: [%"PRId64"]\n", startNumber);
         }
     }
     return startNumber;
@@ -1619,6 +1619,11 @@ static void fix_start_number(DASHContext* c, struct representation** old_reps, s
         struct representation *last_rep = old_reps[i];
         struct representation *new_rep = new_reps[i];
         if (!new_rep->found_start_number && new_rep->timelines && new_rep->n_timelines > 0) {
+            if (!last_rep->last_seq_no) {
+                // We haven't called open_demux_for_component on this representation yet, skip for now. 
+                continue;
+            }
+
             // The representation is using timeline mode - and has no start number hint. So try to guess the start 
             // number by finding where the last segment in the previous version of the representation is in the current
             // representation version. We can use this to find the number of segments which have been dropped since the
@@ -2230,7 +2235,7 @@ static int open_demux_for_component(AVFormatContext *s, struct representation *p
 
     pls->parent = s;
 
-    // First load/refresh... guess the start number using the timeline and duration
+    // Guess the start number using the timeline and duration (if not set)
     pls->start_number = pls->first_seq_no = guess_start_number(c, pls);
     if (!pls->last_seq_no) {
         pls->last_seq_no = calc_max_seg_no(pls, s->priv_data);

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -1335,6 +1335,7 @@ static int parse_manifest(AVFormatContext *s, const char *url, AVIOContext *in)
                 av_log(s, AV_LOG_TRACE, "c->publish_time = [%"PRId64"]\n", c->publish_time);
             } else if (!av_strcasecmp(attr->name, "minimumUpdatePeriod")) {
                 c->minimum_update_period = get_duration_insec(s, val);
+                c->reload_retry_interval = (c->minimum_update_period * 1000) / 2;
                 av_log(s, AV_LOG_TRACE, "c->minimum_update_period = [%"PRId64"]\n", c->minimum_update_period);
             } else if (!av_strcasecmp(attr->name, "timeShiftBufferDepth")) {
                 c->time_shift_buffer_depth = get_duration_insec(s, val);
@@ -1588,6 +1589,11 @@ static void move_segments(struct representation *rep_src, struct representation 
 }
 
 static void fix_start_number(DASHContext* c, struct representation** old_reps, struct representation** new_reps, int n_reps, const char* label) {
+    int64_t last_end_time = 0;
+    int64_t last_seq_no = 0;
+    int64_t new_last_seq_no = 0;
+    int64_t new_start_number = 0;
+
     if (!c->use_timeline_segment_offset_correction) {
         return;
     }
@@ -1606,8 +1612,8 @@ static void fix_start_number(DASHContext* c, struct representation** old_reps, s
             // representation version. We can use this to find the number of segments which have been dropped since the
             // representation was updated. We can then infer the new start_number based on this information, and the
             // previous version of the representations start_number.
-            int64_t last_end_time = get_segment_start_time_based_on_timeline(c, last_rep, last_rep->last_seq_no) / last_rep->fragment_timescale;
-            int64_t last_seq_no = calc_next_seg_no_from_timelines(c, new_rep, last_end_time * new_rep->fragment_timescale - 1);
+            last_end_time = get_segment_start_time_based_on_timeline(c, last_rep, last_rep->last_seq_no) / last_rep->fragment_timescale;
+            last_seq_no = calc_next_seg_no_from_timelines(c, new_rep, last_end_time * new_rep->fragment_timescale - 1);
             if (last_seq_no < 0) {
                 // Previous edge sequence is outside of the current playlist... which means that an entire timeShiftBufferDepth worth
                 // of time (or more) has passed and every segment in the playlist is new... we should be ok just restarting numbering
@@ -1615,15 +1621,15 @@ static void fix_start_number(DASHContext* c, struct representation** old_reps, s
                 av_log(c, AV_LOG_WARNING, "Previous edge segment not found in manifest, discontinuity suspected. Segment numbers may be reset.\n");
                 continue;
             }
-            int64_t new_last_seq_no = calc_max_seg_no(new_rep, c);
+            new_last_seq_no = calc_max_seg_no(new_rep, c);
             av_log(c, AV_LOG_DEBUG, "Checking if %s start_number needes fixing, last_end_time: [%"PRId64"] last_seq_no: [%"PRId64"], new_last_seq_no: [%"PRId64"], last_start_number: [%"PRId64"], new_start_number: [%"PRId64"]\n",
                    label, last_end_time, last_seq_no, new_last_seq_no, last_rep->start_number, new_rep->start_number);
-            int64_t startNumber = last_rep->start_number + (new_last_seq_no - last_seq_no);
-            if (new_rep->start_number != startNumber) {
+            new_start_number = last_rep->start_number + (new_last_seq_no - last_seq_no);
+            if (new_rep->start_number != new_start_number) {
                 // Update start/first_seq_no (last_seq_no will be recalculated in move_timelines/move_segments)
                 av_log(c, AV_LOG_DEBUG, "Fixing %s timeline. start_number: [%"PRId64"] first_seq_no: [%"PRId64"], new: [%"PRId64"]\n",
-                        label, new_rep->start_number, new_rep->first_seq_no, startNumber);
-                new_rep->start_number = new_rep->first_seq_no = startNumber;
+                        label, new_rep->start_number, new_rep->first_seq_no, new_start_number);
+                new_rep->start_number = new_rep->first_seq_no = new_start_number;
             }
         }
     }
@@ -1982,24 +1988,16 @@ static int64_t seek_data(void *opaque, int64_t offset, int whence)
     return AVERROR(ENOSYS);
 }
 
-static void delay_reload(DASHContext *c, int reload_count)
+static void delay_reload(DASHContext *c, int64_t reload_count)
 {
     int delay = 0;
 
-    // Attempt first reload immediately,
-    if (reload_count == 1)
-    {
-        delay = 0;
-    }
-    else if (c->reload_retry_interval < 0)
-    {
-        delay = c->minimum_update_period * 1000 * 1000 / 2;
-    }
-    else {
+    // Attempt first reload immediately, otherwise wait the reload
+    if (reload_count > 1) {
         delay = c->reload_retry_interval * 1000;
     }
     if (delay > 0) {
-        av_log(c, AV_LOG_DEBUG, "Segment not ready, retrying again in: [%"PRId64"]ms\n", delay/1000);
+        av_log(c, AV_LOG_DEBUG, "Segment not ready (reload_count: %"PRId64"), retrying again in %ldms\n", reload_count, delay/1000);
         av_usleep(delay);
     }
 }
@@ -2671,7 +2669,7 @@ static const AVOption dash_options[] = {
     { "start_on_live_edge", "Start processing at the latest segment for live manifests",
         OFFSET(start_on_live_edge), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, FLAGS},
     {"max_reload", "Maximum number of times a list is attempted to be reloaded during live (dynamic) playback",
-        OFFSET(max_reload), AV_OPT_TYPE_INT, {.i64 = 1000}, 0, INT_MAX, FLAGS},
+        OFFSET(max_reload), AV_OPT_TYPE_INT, {.i64 = 100}, 0, INT_MAX, FLAGS},
     {"reload_retry_interval", "Interval in ms to wait before retrying playlist reload. If not set, defaults to mimumumUpdatePeriod/2",
         OFFSET(reload_retry_interval), AV_OPT_TYPE_INT, {.i64 = -1}, 0, INT_MAX, FLAGS},
     {NULL}


### PR DESCRIPTION
Summary:
- Infer the start number from the previous segment information if its missing (instead of resetting to 0 every reload)
- Sleep/retry if an attempt to read past of the end of the playlist occurs (instead of replaying the edge segment)

TODO:
- [x] re-review places cur_seq_no is modified
- [x] put stuff behind config
- [x] fix TODO in fix_start_number
- [x] fix TODO in retry logic