### PR TITLE
libavformat/dashdec.c: guess start number using segment time

### DIFF
--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -1589,17 +1589,16 @@ static void move_segments(struct representation *rep_src, struct representation 
 }
 
 static int64_t guess_start_number(DASHContext* c, struct representation* rep) {
-    int64_t duration = rep->fragment_duration;
+    int64_t duration;
+    int64_t time;
     int64_t startNumber = rep->start_number;
-    if (c->use_timeline_segment_offset_correction && !rep->found_start_number && rep->timelines && rep->n_timelines) {
-        // Best guess: ((wall clock time - availabilityStartTime ) / (duration / timescale ))
-        if (!duration) {
-            // The timeline segment duration can vary +/-50% between segments, but its our best guess.
-            duration = rep->timelines[0]->duration;
-        }
+    if (c->use_timeline_segment_offset_correction && c->is_live && !rep->found_start_number && rep->timelines && rep->n_timelines) {
+        // The timeline segment duration can vary +/-50% between segments, but its our best guess.
+        duration = rep->timelines[0]->duration;
+        time = rep->timelines[0]->starttime;
         if (duration) {
-            startNumber = ((get_current_time_in_sec() - c->availability_start_time) * rep->fragment_timescale)/ (duration);
-            av_log(c, AV_LOG_DEBUG, "Guessing start_number from timeline: [%"PRId64"]\n", startNumber);
+            startNumber = time / duration;
+            av_log(c, AV_LOG_DEBUG, "Guessing start_number from segment starttime [%"PRId64"] and duration [%"PRId64"] -> [%"PRId64"]\n", time, duration, startNumber);
         }
     }
     return startNumber;
@@ -1611,7 +1610,7 @@ static void fix_start_number(DASHContext* c, struct representation** old_reps, s
     int64_t new_last_seq_no = 0;
     int64_t new_start_number = 0;
 
-    if (!c->use_timeline_segment_offset_correction) {
+    if (!c->use_timeline_segment_offset_correction || !c->is_live) {
         return;
     }
 


### PR DESCRIPTION
Previous attempt to guess segment number using the formula
`((wall clock time - availabilityStartTime ) / (duration / timescale ))`

Resulted in VERY large segment numbers (eg: 888094599) because the MPD we have from our customer has availabilityStartTime set to the unix epoch  (1970, the default value). The period start time does indicate an offset of ~54 years, which means its all technically correct (including, arguably, the very large segment number we guess).

I went hunting for more examples of what real world MPDs look like 
- most had a start_number and this is all moot
- should probably only bother with the guessing if its a dynamic playlist, otherwise 0 is OK
- some had availabilityStartTime unset/defaulted, but then the period has no start

So... I think the last version was still arguably correct, but I think its better to just use the pts/segment time value to estimate, which gives a segment number guess of 791751 in the customer example, which better maps the actual playtime of the stream  (2-3 weeks).

At the end of the day - these are just a guess. Internally the code doesn't care if we start at 0 or 999999999. So this is really mostly for cosmetic/segNumber reporting.