### PR TITLE
dashdec.c: return EOF when read_from_url reads 0 bytes to prevent infinite loop

### DIFF
--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -2135,8 +2135,12 @@ restart:
     }
 
     ret = read_from_url(v, v->cur_seg, buf, buf_size);
-    if (ret > 0)
+    if (ret > 0) {
         goto end;
+    } else if (ret == 0) {
+        // No bytes read, assume EOF.
+        ret = AVERROR_EOF;
+    }
 
     if (c->is_live || v->cur_seq_no < v->last_seq_no) {
         if (!v->is_restart_needed)

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -2144,11 +2144,8 @@ restart:
         // - This seems to occur when the file is invalid or replaced on disk (hard to say).
         // - To prevent this make sure we return EOF when 0 bytes are read, avio_seek will treat this as EOF, and normal DASH decoding
         //   will simply try again/load the next segment.
+        av_log(v->parent, AV_LOG_DEBUG, "EOF reached, file: %s\n", v->cur_seg->url);
         ret = AVERROR_EOF;
-        if (v->is_restart_needed) {
-            // Attempt to log when the above error occurs.
-            av_log(v->parent, AV_LOG_ERROR, "EOF reached while attempting to read new segment, file: %s\n", v->cur_seg->url);
-        }
     }
 
     if (c->is_live || v->cur_seq_no < v->last_seq_no) {

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -2139,6 +2139,7 @@ restart:
         goto end;
     } else if (ret == 0) {
         // No bytes read, assume EOF.
+        av_log(v->parent, AV_LOG_ERROR, "No bytes read, assume, file: %s\n", v->cur_seg->url);
         ret = AVERROR_EOF;
     }
 

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -2138,9 +2138,17 @@ restart:
     if (ret > 0) {
         goto end;
     } else if (ret == 0) {
-        // No bytes read, assume EOF.
-        av_log(v->parent, AV_LOG_ERROR, "No bytes read, assume, file: %s\n", v->cur_seg->url);
+        // NOTE:
+        // - mov_read_header->mov_read_default->avio_seek->fill_buffers will sometimes try to seek past EOF when decoding headers.
+        //   read_from_url will ignore the call and return 0 (but not set the eof flag). This can cause an infinite loop.
+        // - This seems to occur when the file is invalid or replaced on disk (hard to say).
+        // - To prevent this make sure we return EOF when 0 bytes are read, avio_seek will treat this as EOF, and normal DASH decoding
+        //   will simply try again/load the next segment.
         ret = AVERROR_EOF;
+        if (v->is_restart_needed) {
+            // Attempt to log when the above error occurs.
+            av_log(v->parent, AV_LOG_ERROR, "EOF reached while attempting to read new segment, file: %s\n", v->cur_seg->url);
+        }
     }
 
     if (c->is_live || v->cur_seq_no < v->last_seq_no) {


### PR DESCRIPTION
dashdec.c: return EOF when read_from_url reads 0 bytes to prevent infinite loop when EOF hit during new segment loading and avio_read attempt to seek past EOF when skipping headers.