### PR TITLE
hls/dashdec: Report end of playlists in metadata

### DIFF
--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -1620,11 +1620,11 @@ static void fix_start_number(DASHContext* c, struct representation** old_reps, s
         struct representation *new_rep = new_reps[i];
         if (!new_rep->found_start_number && new_rep->timelines && new_rep->n_timelines > 0) {
             if (!last_rep->last_seq_no) {
-                // We haven't called open_demux_for_component on this representation yet, skip for now. 
+                // We haven't called open_demux_for_component on this representation yet, skip for now.
                 continue;
             }
 
-            // The representation is using timeline mode - and has no start number hint. So try to guess the start 
+            // The representation is using timeline mode - and has no start number hint. So try to guess the start
             // number by finding where the last segment in the previous version of the representation is in the current
             // representation version. We can use this to find the number of segments which have been dropped since the
             // representation was updated. We can then infer the new start_number based on this information, and the
@@ -2379,6 +2379,7 @@ static int dash_read_header(AVFormatContext *s)
     } else {
         av_dict_set(&c->avio_opts, "seekable", "0", 0);
     }
+    av_dict_set_int(&s->metadata, "dynamic", c->is_live, 0);
 
     if(c->n_videos)
         c->is_init_section_common_video = is_common_init_section_exist(c->videos, c->n_videos);

--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -2368,8 +2368,14 @@ static int hls_read_header(AVFormatContext *s)
          * Copy any metadata from playlist to main streams, but do not set
          * event flags.
          */
-        if (pls->n_main_streams)
+        if (pls->n_main_streams) {
             av_dict_copy(&pls->main_streams[0]->metadata, pls->ctx->metadata, 0);
+
+            for (size_t j = 0; j < pls->n_main_streams; j++) {
+                AVStream *st = pls->main_streams[j];
+                av_dict_set_int(&st->metadata, "finished", pls->finished, 0);
+            }
+        }
 
         add_metadata_from_renditions(s, pls, AVMEDIA_TYPE_AUDIO);
         add_metadata_from_renditions(s, pls, AVMEDIA_TYPE_VIDEO);
@@ -2587,6 +2593,10 @@ static int hls_read_packet(AVFormatContext *s, AVPacket *pkt)
                 st->event_flags |= AVSTREAM_EVENT_FLAG_METADATA_UPDATED;
             }
             pls->ctx->event_flags &= ~AVFMT_EVENT_FLAG_METADATA_UPDATED;
+        }
+        for (size_t j = 0; j < pls->n_main_streams; j++) {
+            AVStream *st = pls->main_streams[j];
+            av_dict_set_int(&st->metadata, "finished", pls->finished, 0);
         }
 
         /* check if noheader flag has been cleared by the subdemuxer */


### PR DESCRIPTION
Each time the playlist is read, refresh the metadata with whether or not the playlist has a defined end.

For DASH, the top level MPD reports the playlist as "static", and that applies to all child streams.
For HLS, the media playlists have an #EXT-X-ENDLIST tag, which applies to that specific stream.