### PR TITLE
dashdec: representation filtering and live edge time reporting

### DIFF
--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -2579,6 +2579,7 @@ static int dash_read_packet(AVFormatContext *s, AVPacket *pkt)
 
             if (cur->n_timelines) {
                 av_dict_set_int(&metadata_dict, "segStartTime", get_segment_start_time_based_on_timeline(c, cur, cur->cur_seq_no), 0);
+                av_dict_set_int(&metadata_dict, "liveEdgeSegStartTime", get_segment_start_time_based_on_timeline(c, cur, 0xFFFFFFFF), 0);
                 av_dict_set_int(&metadata_dict, "fragDuration", cur->timelines[0]->duration, 0);
             }
             else {

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -912,6 +912,26 @@ static int parse_manifest_representation(AVFormatContext *s, const char *url,
         av_log(s, AV_LOG_VERBOSE, "Parsing '%s' - skipp not supported representation type\n", url);
         return 0;
     }
+    else {
+        // convert selected representation to our internal struct
+        val = xmlGetProp(representation_node, "id");
+        if (val && c->selected_video_rep_id && type == AVMEDIA_TYPE_VIDEO) {
+            size_t lengthVal = strlen(val);
+            size_t lengthSelected = strlen(c->selected_video_rep_id);
+            if (strncmp(val, c->selected_video_rep_id, lengthVal)) {
+                xmlFree(val);
+                return 0;
+            }
+        }
+        else if (val && c->selected_audio_rep_id && type == AVMEDIA_TYPE_AUDIO) {
+            size_t lengthVal = strlen(val);
+            size_t lengthSelected = strlen(c->selected_audio_rep_id);
+            if (strncmp(val, c->selected_audio_rep_id, lengthVal)) {
+                xmlFree(val);
+                return 0;
+            }
+        }
+    }
 
     // convert selected representation to our internal struct
     rep = av_mallocz(sizeof(struct representation));


### PR DESCRIPTION
Skip parsing representations for audio/video streams that we're not processing.  This avoids any additional overhead housekeeping that is done for streams referenced by the MPD.  This was a patch we had applied years ago that got lost in ffmpeg updates.

Add the start time of the segment at the live edge in the packet metadata.