### PR TITLE
Move filesize reporting before dict checking.

### DIFF
--- a/libavformat/crypto.c
+++ b/libavformat/crypto.c
@@ -147,6 +147,11 @@ static int crypto_open2(URLContext *h, const char *uri, int flags, AVDictionary 
         goto err;
     }
 
+    if (c->hd && c->hd->filesize_reported) {
+        h->filesize_reported = c->hd->filesize_reported;
+        h->filesize = c->hd->filesize;
+    }
+
     if (flags & AVIO_FLAG_READ) {
         c->aes_decrypt = av_aes_alloc();
         if (!c->aes_decrypt) {

--- a/libavformat/http.c
+++ b/libavformat/http.c
@@ -188,6 +188,9 @@ static int http_shutdown(URLContext *h, int flags);
 static void http_add_status_data(URLContext* h, AVDictionary** dict) {
     HTTPContext *s = h->priv_data;
 
+    h->filesize = s->filesize;
+    h->filesize_reported = 1;
+
     if (!dict) {
         return;
     }
@@ -199,9 +202,6 @@ static void http_add_status_data(URLContext* h, AVDictionary** dict) {
         av_dict_set(dict, "http_cache_method", s->post_data ? "POST" : "GET", 0);
     }
     av_dict_set_int(dict, "http_cache_status_code", s->http_code, 0);
-
-    h->filesize = s->filesize;
-    h->filesize_reported = 1;
 }
 
 void ff_http_init_auth_state(URLContext *dest, const URLContext *src)


### PR DESCRIPTION
 Forward filesizes through the crypto chain.