### PR TITLE
Add more options in ffio_copy_url_options

### DIFF
--- a/libavformat/aviobuf.c
+++ b/libavformat/aviobuf.c
@@ -1023,7 +1023,24 @@ URLContext* ffio_geturlcontext(AVIOContext *s)
 int ffio_copy_url_options(AVIOContext* pb, AVDictionary** avio_opts)
 {
     const char *opts[] = {
-        "headers", "user_agent", "cookies", "http_proxy", "referer", "rw_timeout", "icy", NULL };
+        "http_proxy",
+        "headers",
+        "multiple_requests",
+        "user_agent",
+        "referer", 
+        "cookies", 
+        "http_proxy",
+        "rw_timeout",
+        "icy",
+        "send_expect_100",
+        "reconnect",
+        "reconnect_at_eof",
+        "reconnect_on_network_error",
+        "reconnect_on_http_error",
+        "reconnect_streamed",
+        "reconnect_delay_max",
+        NULL 
+    };
     const char **opt = opts;
     uint8_t *buf = NULL;
     int ret = 0;


### PR DESCRIPTION
I ffio_copy_url_options ffmpegs ffio_copy_url_options to copy over some HTTP parameters years ago when IMF was introduced so IMF/HLS/DASH properly copied to sub variants.

No idea why I didn't do more options.... or why no one called me out on it when I upstreamed, but if we want things like IMF (a playlist wrapping MXF videos and audio basically) to obey reconnect, http_persist etc, then this change is needed.