### PR TITLE
Reload when failed to get media playlist.

### DIFF
--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -2857,7 +2857,7 @@ static const AVOption hls_options[] = {
         {.str = ""}, 0, 0, FLAGS},
     { "use_independent_segment_fetch_for_obtaining_size", "Use patch for obtaining segment size (ie. double download)",
         OFFSET(use_independent_segment_fetch_for_obtaining_size), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, FLAGS},
-    { "reload_variant_playlist_on_http_error", "Reload when faild to get the variant playlist during processing segments.",
+    { "reload_variant_playlist_on_http_error", "Reload when failed to get the variant playlist during processing segments.",
         OFFSET(reload_variant_playlist_on_http_error), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, FLAGS},
     {NULL}
 };

--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -256,6 +256,7 @@ typedef struct HLSContext {
     char *sample_aes_iv;
     char *sample_aes_cek_location;
     int use_independent_segment_fetch_for_obtaining_size;
+    int reload_variant_playlist_on_http_error;
 } HLSContext;
 
 static int64_t get_actual_segment_size(struct playlist *pls, struct segment* seg) {
@@ -1634,11 +1635,21 @@ reload:
                 if (ret != AVERROR_EXIT)
                     av_log(v->parent, AV_LOG_WARNING, "Failed to reload playlist %d\n",
                            v->index);
-                if (ret == AVERROR_HTTP_NOT_FOUND) {
-                    av_log(v->parent, AV_LOG_DEBUG, "Going to reload playlist %d, reload count %d\n",
-                           v->index, reload_count);
-                    av_usleep(reload_interval);
-                    goto reload;
+                if (c->reload_variant_playlist_on_http_error) {
+                    switch (ret) {
+                        case AVERROR_HTTP_NOT_FOUND:
+                        case AVERROR_HTTP_OTHER_4XX:
+                        case AVERROR_HTTP_SERVER_ERROR:
+                            {
+                                av_log(v->parent, AV_LOG_DEBUG, "Going to reload playlist %d, reload count %d\n",
+                                    v->index, reload_count);
+                                av_usleep(reload_interval);
+                                goto reload;
+                            }
+                            break;
+                        default:
+                            break;
+                    }
                 }
                 return ret;
             }
@@ -2846,6 +2857,8 @@ static const AVOption hls_options[] = {
         {.str = ""}, 0, 0, FLAGS},
     { "use_independent_segment_fetch_for_obtaining_size", "Use patch for obtaining segment size (ie. double download)",
         OFFSET(use_independent_segment_fetch_for_obtaining_size), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, FLAGS},
+    { "reload_variant_playlist_on_http_error", "Reload when faild to get the variant playlist during processing segments.",
+        OFFSET(reload_variant_playlist_on_http_error), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, FLAGS},
     {NULL}
 };
 

--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -1634,6 +1634,12 @@ reload:
                 if (ret != AVERROR_EXIT)
                     av_log(v->parent, AV_LOG_WARNING, "Failed to reload playlist %d\n",
                            v->index);
+                if (ret == AVERROR_HTTP_NOT_FOUND) {
+                    av_log(v->parent, AV_LOG_DEBUG, "Going to reload playlist %d, reload count %d\n",
+                           v->index, reload_count);
+                    av_usleep(reload_interval);
+                    goto reload;
+                }
                 return ret;
             }
 


### PR DESCRIPTION
The problem is:
The analyzer exit when got 404 response code when fetching a media playlist file in some cases.
In the above failed case , ReadFrame(packetContext) got  AVERROR_HTTP_NOT_FOUND then push a null packet to end the processing when open_segment(struct playlist *v)  returned AVERROR_HTTP_NOT_FOUND

These are all defined errors:
```
#define AVERROR_HTTP_BAD_REQUEST   FFERRTAG(0xF8,'4','0','0')
#define AVERROR_HTTP_UNAUTHORIZED  FFERRTAG(0xF8,'4','0','1')
#define AVERROR_HTTP_FORBIDDEN     FFERRTAG(0xF8,'4','0','3')
#define AVERROR_HTTP_NOT_FOUND     FFERRTAG(0xF8,'4','0','4')
#define AVERROR_HTTP_OTHER_4XX     FFERRTAG(0xF8,'4','X','X')
#define AVERROR_HTTP_SERVER_ERROR  FFERRTAG(0xF8,'5','X','X')
```
I think we only need to reload when 
```
#define AVERROR_HTTP_NOT_FOUND     FFERRTAG(0xF8,'4','0','4')
#define AVERROR_HTTP_OTHER_4XX     FFERRTAG(0xF8,'4','X','X')
#define AVERROR_HTTP_SERVER_ERROR  FFERRTAG(0xF8,'5','X','X')
```
Exit on other errors which need to figure out the reason

I tested this fix and it worked for StreamAware On-Air to fix this issue but not confident about if it is doing right thing for all products.