### PR TITLE
DASH (live): Fail quicker if the playlists are missing segments

### DIFF
--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -2290,9 +2290,11 @@ static int open_demux_for_component(AVFormatContext *s, struct representation *p
     if (!pls->last_seq_no) {
         pls->last_seq_no = calc_max_seg_no(pls, s->priv_data);
         if (!pls->last_seq_no) {
-            av_log(pls->parent, AV_LOG_ERROR, "DASH missing valid timeline or segments\n");
-            ret = AVERROR_INVALIDDATA;
-            goto fail;
+            if (c->is_live) {
+                av_log(pls->parent, AV_LOG_WARNING, "DASH manifest has no valid segments\n");
+                ret = AVERROR(EAGAIN);
+                goto fail;
+            }
         }
     }
     pls->cur_seq_no  = calc_cur_seg_no(s, pls);

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -2291,7 +2291,7 @@ static int open_demux_for_component(AVFormatContext *s, struct representation *p
         pls->last_seq_no = calc_max_seg_no(pls, s->priv_data);
         if (!pls->last_seq_no) {
             av_log(pls->parent, AV_LOG_ERROR, "DASH missing valid timeline or segments\n");
-            ret = AVERROR_INVALIDDATA
+            ret = AVERROR_INVALIDDATA;
             goto fail;
         }
     }

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -2290,7 +2290,7 @@ static int open_demux_for_component(AVFormatContext *s, struct representation *p
     if (!pls->last_seq_no) {
         if (c->is_live && !calc_max_seg_no(pls, s->priv_data)) {
             av_log(pls->parent, AV_LOG_WARNING, "DASH manifest has no valid segments\n");
-            ret = AVERROR(EAGAIN);
+            ret = AVERROR_INVALIDDATA;
             goto fail;
         }
         pls->last_seq_no = calc_max_seg_no(pls, s->priv_data);

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -2292,7 +2292,7 @@ static int open_demux_for_component(AVFormatContext *s, struct representation *p
         if (!pls->last_seq_no) {
             av_log(pls->parent, AV_LOG_ERROR, "DASH missing valid timeline or segments\n");
             ret = AVERROR_INVALIDDATA
-            goto fail:
+            goto fail;
         }
     }
     pls->cur_seq_no  = calc_cur_seg_no(s, pls);

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -2289,6 +2289,11 @@ static int open_demux_for_component(AVFormatContext *s, struct representation *p
     pls->start_number = pls->first_seq_no = guess_start_number(c, pls);
     if (!pls->last_seq_no) {
         pls->last_seq_no = calc_max_seg_no(pls, s->priv_data);
+        if (!pls->last_seq_no) {
+            av_log(pls->parent, AV_LOG_ERROR, "DASH missing valid timeline or segments\n");
+            ret = AVERROR_INVALIDDATA
+            goto fail:
+        }
     }
     pls->cur_seq_no  = calc_cur_seg_no(s, pls);
 

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -2288,14 +2288,12 @@ static int open_demux_for_component(AVFormatContext *s, struct representation *p
     // Guess the start number using the timeline and duration (if not set)
     pls->start_number = pls->first_seq_no = guess_start_number(c, pls);
     if (!pls->last_seq_no) {
-        pls->last_seq_no = calc_max_seg_no(pls, s->priv_data);
-        if (!pls->last_seq_no) {
-            if (c->is_live) {
-                av_log(pls->parent, AV_LOG_WARNING, "DASH manifest has no valid segments\n");
-                ret = AVERROR(EAGAIN);
-                goto fail;
-            }
+        if (c->is_live && !calc_max_seg_no(pls, s->priv_data)) {
+            av_log(pls->parent, AV_LOG_WARNING, "DASH manifest has no valid segments\n");
+            ret = AVERROR(EAGAIN);
+            goto fail;
         }
+        pls->last_seq_no = calc_max_seg_no(pls, s->priv_data);
     }
     pls->cur_seq_no  = calc_cur_seg_no(s, pls);
 


### PR DESCRIPTION
FFMPEG doesn't handle it when the playlist exists, but has an empty timeline/segment list.

Basically it gets stuck forever trying to read segment "0" even though startNumber is 1 or greater, and it never updates this.

This is required because of  behavior in ffmpeg/libavformat/dashdec.c update_init_section() function, when it gets the initial manifest, it needs to load both the init fragment and the first content fragment.

I tried for a while to workaround this by reloading the manifest but it was none-trivial and getting complicated. Rather than spending a week trying to get it to work when we are planning on stopping the use of the DASH demuxer anyways, I figured better to get this to fail fast so at least we retry sooner (and spam the logs less with internal FFMPEG warnings).