### PR TITLE
libavcodec/hevc: Remove extraneous check. Update print for field order

### DIFF
--- a/libavcodec/avcodec.c
+++ b/libavcodec/avcodec.c
@@ -596,6 +596,10 @@ void avcodec_string(char *buf, int buf_size, AVCodecContext *enc, int encode)
                     field_order = "top coded first (swapped)";
                 else if (enc->field_order == AV_FIELD_BT)
                     field_order = "bottom coded first (swapped)";
+                else if (enc->field_order == AV_FIELD_PAIRED_TB)
+                    field_order = "field paired top first";
+                else if (enc->field_order == AV_FIELD_PAIRED_BT)
+                    field_order = "field paired bottom first";
 
                 av_bprintf(&bprint, "%s, ", field_order);
             }

--- a/libavcodec/hevc/parser.c
+++ b/libavcodec/hevc/parser.c
@@ -69,13 +69,11 @@ static int hevc_parse_slice_header(AVCodecParserContext *s, H2645NAL *nal,
     first_slice_in_pic_flag = get_bits1(gb);
     s->picture_structure = sei->picture_timing.picture_struct;
     s->field_order = sei->picture_timing.picture_struct;
-    if (sei->picture_timing.hevc_picture_struct > 8) {
-        if (sei->picture_timing.hevc_picture_struct == 9 || sei->picture_timing.hevc_picture_struct == 12) {
-            s->field_order = AV_FIELD_PAIRED_BT;
-        }
-        else if (sei->picture_timing.hevc_picture_struct == 10 || sei->picture_timing.hevc_picture_struct == 11) {
-            s->field_order = AV_FIELD_PAIRED_TB;
-        }
+    if (sei->picture_timing.hevc_picture_struct == 9 || sei->picture_timing.hevc_picture_struct == 11) {
+        s->field_order = AV_FIELD_PAIRED_TB;
+    }
+    else if (sei->picture_timing.hevc_picture_struct == 10 || sei->picture_timing.hevc_picture_struct == 12) {
+        s->field_order = AV_FIELD_PAIRED_BT;
     }
 
     if (IS_IRAP_NAL(nal)) {


### PR DESCRIPTION
When preparing to upstream I noticed that we are mis-assigning the field order for picture struct. This would cause a misalignment in application when we weaved the fields together. 