### PR TITLE
libavcodec/hevc: Add some comments as to why the HEVC matching is the…

### DIFF
--- a/libavcodec/hevc/parser.c
+++ b/libavcodec/hevc/parser.c
@@ -69,11 +69,17 @@ static int hevc_parse_slice_header(AVCodecParserContext *s, H2645NAL *nal,
     first_slice_in_pic_flag = get_bits1(gb);
     s->picture_structure = sei->picture_timing.picture_struct;
     s->field_order = sei->picture_timing.picture_struct;
-    if (sei->picture_timing.hevc_picture_struct == 9 || sei->picture_timing.hevc_picture_struct == 11) {
-        s->field_order = AV_FIELD_PAIRED_TB;
-    }
-    else if (sei->picture_timing.hevc_picture_struct == 10 || sei->picture_timing.hevc_picture_struct == 12) {
+    /* HEVC field coding has the following table
+       Top Field paired with previous Bottom Field:  9 (AV_FIELD_PAIRED_BT)
+       Top Field paired with next Bottom Field:     10 (AV_FIELD_PAIRED_TB)
+       Bottom Field paired with previous Top Field: 11 (AV_FIELD_PAIRED_TB)
+       Bottom Field paired with next Top Field:     12 (AV_FIELD_PAIRED_BT)
+    */
+    if (sei->picture_timing.hevc_picture_struct == 9 || sei->picture_timing.hevc_picture_struct == 12) {
         s->field_order = AV_FIELD_PAIRED_BT;
+    }
+    else if (sei->picture_timing.hevc_picture_struct == 10 || sei->picture_timing.hevc_picture_struct == 11) {
+        s->field_order = AV_FIELD_PAIRED_TB;
     }
 
     if (IS_IRAP_NAL(nal)) {


### PR DESCRIPTION
When revisiting https://github.com/Intel-Media-SDK/MediaSDK/blob/master/doc/mediasdk_hevc_interlace_whitepaper.md I realised why we had those fields set. Revert the change in the previous commit and add some commetns.